### PR TITLE
兼容YSM并修复一些问题

### DIFF
--- a/common/src/main/java/com/shiroha/mmdskin/config/ConfigData.java
+++ b/common/src/main/java/com/shiroha/mmdskin/config/ConfigData.java
@@ -97,6 +97,8 @@ public class ConfigData {
 
     // 第一人称模型显示
     public boolean firstPersonModelEnabled = false;
+    public float firstPersonCameraForwardOffset = 0.0f;
+    public float firstPersonCameraVerticalOffset = 0.0f;
     
     /**
      * 从文件加载配置
@@ -200,5 +202,7 @@ public class ConfigData {
         other.physicsDebugLog = this.physicsDebugLog;
         // 第一人称
         other.firstPersonModelEnabled = this.firstPersonModelEnabled;
+        other.firstPersonCameraForwardOffset = this.firstPersonCameraForwardOffset;
+        other.firstPersonCameraVerticalOffset = this.firstPersonCameraVerticalOffset;
     }
 }

--- a/common/src/main/java/com/shiroha/mmdskin/renderer/camera/MMDCameraController.java
+++ b/common/src/main/java/com/shiroha/mmdskin/renderer/camera/MMDCameraController.java
@@ -67,7 +67,7 @@ public class MMDCameraController {
     private long modelHandle = 0;
     
     // 音频播放器
-    private final StageAudioPlayer audioPlayer = new StageAudioPlayer();
+    private final StageAudioPlayer audioPlayer = StageAudioPlayer.getInstance();
     
     // 相机数据
     private final MMDCameraData cameraData = new MMDCameraData();
@@ -114,6 +114,13 @@ public class MMDCameraController {
     public static MMDCameraController getInstance() {
         return INSTANCE;
     }
+
+    /**
+     * 判断是否处于舞台模式（供 Mixin 调用）
+     */
+    public boolean isInStageMode() {
+        return this.state != StageState.INACTIVE;
+    }
     
     // ==================== 生命周期方法 ====================
     
@@ -136,6 +143,11 @@ public class MMDCameraController {
             this.anchorY = mc.player.getY();
             this.anchorZ = mc.player.getZ();
             this.anchorYaw = mc.player.getYRot();
+            // 重置玩家朝向，确保进入舞台时面向正前方
+            mc.player.setXRot(0.0f);
+            mc.player.setYRot(this.anchorYaw);
+            mc.player.yHeadRot = this.anchorYaw;
+            mc.player.yBodyRot = this.anchorYaw;
         }
         
         // 重载模型（清除上次播放的残留姿势，仅本地玩家）

--- a/common/src/main/java/com/shiroha/mmdskin/renderer/core/FirstPersonManager.java
+++ b/common/src/main/java/com/shiroha/mmdskin/renderer/core/FirstPersonManager.java
@@ -4,6 +4,10 @@ import com.shiroha.mmdskin.NativeFunc;
 import com.shiroha.mmdskin.config.ConfigManager;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,7 +40,24 @@ public final class FirstPersonManager {
     /** 眼睛骨骼是否有效（至少有一个分量非零） */
     private static boolean eyeBoneValid = false;
 
+    /** 记录最后一帧摄像机位置，用于修复十字准星偏移 */
+    private static Vec3 lastCameraPos = Vec3.ZERO;
+
     private FirstPersonManager() {}
+
+    /**
+     * 设置最后一帧摄像机位置
+     */
+    public static void setLastCameraPos(Vec3 pos) {
+        lastCameraPos = pos;
+    }
+
+    /**
+     * 获取最后一帧摄像机位置
+     */
+    public static Vec3 getLastCameraPos() {
+        return lastCameraPos;
+    }
 
     /**
      * 判断当前是否应该使用第一人称模型渲染
@@ -123,6 +144,26 @@ public final class FirstPersonManager {
         out[0] = eyeBonePos[0] * scale;
         out[1] = eyeBonePos[1] * scale;
         out[2] = eyeBonePos[2] * scale;
+    }
+
+    /**
+     * 获取考虑旋转后的眼睛世界坐标位置
+     */
+    public static Vec3 getRotatedEyePosition(Entity entity, float partialTick) {
+        float[] eyeOffset = new float[3];
+        getEyeWorldOffset(eyeOffset);
+        double px = Mth.lerp(partialTick, entity.xo, entity.getX());
+        double py = Mth.lerp(partialTick, entity.yo, entity.getY());
+        double pz = Mth.lerp(partialTick, entity.zo, entity.getZ());
+        float bodyYaw = entity instanceof LivingEntity le
+                ? Mth.lerp(partialTick, le.yBodyRotO, le.yBodyRot)
+                : Mth.lerp(partialTick, entity.yRotO, entity.getYRot());
+        float yawRad = (float) Math.toRadians(bodyYaw);
+        double sinYaw = Math.sin(yawRad);
+        double cosYaw = Math.cos(yawRad);
+        double worldOffX = eyeOffset[0] * cosYaw - eyeOffset[2] * sinYaw;
+        double worldOffZ = eyeOffset[0] * sinYaw + eyeOffset[2] * cosYaw;
+        return new Vec3(px + worldOffX, py + eyeOffset[1], pz + worldOffZ);
     }
 
     /**

--- a/common/src/main/java/com/shiroha/mmdskin/renderer/render/MmdSkinRendererPlayerHelper.java
+++ b/common/src/main/java/com/shiroha/mmdskin/renderer/render/MmdSkinRendererPlayerHelper.java
@@ -7,6 +7,7 @@ import com.shiroha.mmdskin.renderer.core.IMMDModel;
 import com.shiroha.mmdskin.renderer.animation.MMDAnimManager;
 import com.shiroha.mmdskin.renderer.model.MMDModelManager;
 import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
+import com.shiroha.mmdskin.renderer.camera.StageAudioPlayer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import org.apache.logging.log4j.LogManager;
@@ -165,6 +166,22 @@ public class MmdSkinRendererPlayerHelper {
         }
         
         logger.info("[舞台同步] 远程玩家 {} 舞台动画结束", playerName);
+    }
+
+    /**
+     * 远程玩家舞台音频同步
+     */
+    public static void StageAudioPlay(Player player, String audioData) {
+        if (player == null || audioData == null || audioData.isEmpty()) return;
+
+        String[] parts = audioData.split("\\|");
+        if (parts.length >= 2) {
+            String packName = parts[0];
+            String audioName = parts[1];
+            String audioPath = new File(PathConstants.getStageAnimDir(), packName + File.separator + audioName).getAbsolutePath();
+            StageAudioPlayer.playRemoteAudio(player, audioPath);
+            logger.info("[舞台同步] 远程玩家 {} 舞台音频已开始: {}/{}", player.getName().getString(), packName, audioName);
+        }
     }
     
     /**

--- a/fabric/src/main/java/com/shiroha/mmdskin/fabric/YsmCompat.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/fabric/YsmCompat.java
@@ -1,0 +1,120 @@
+package com.shiroha.mmdskin.fabric;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.LivingEntity;
+import net.fabricmc.loader.api.FabricLoader;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * YSM (Yes Steve Model) 兼容性辅助类 (Fabric)
+ * 用于检测玩家是否正在使用 YSM 模型，以便 MMD 进行避让
+ */
+public class YsmCompat {
+    private static boolean ysmChecked = false;
+    private static boolean ysmPresent = false;
+    
+    private static Method isModelActiveMethod = null;
+    private static Method getCapabilityMethod = null;
+    private static Object playerAnimatableCap = null;
+    
+    // YSM 配置项字段 (BooleanValue 类型)
+    private static Object disableSelfModelValue = null;
+    private static Object disableOtherModelValue = null;
+    private static Object disableSelfHandsValue = null;
+    
+    // BooleanValue.get() 方法
+    private static Method booleanValueGetMethod = null;
+
+    public static boolean isYsmActive(LivingEntity entity) {
+      if (!isYsmModelActive(entity)) {
+         return false;
+      }
+      
+      Minecraft mc = Minecraft.getInstance();
+      boolean isLocalPlayer = mc.player != null && mc.player.getUUID().equals(entity.getUUID());
+      if (isLocalPlayer) {
+         return !isDisableSelfModel();
+      } else {
+         return !isDisableOtherModel();
+      }
+   }
+
+   /**
+    * 检查实体是否正在使用 YSM 模型
+    */
+   public static boolean isYsmModelActive(LivingEntity entity) {
+      if (!ysmChecked) {
+         ysmPresent = FabricLoader.getInstance().isModLoaded("yes_steve_model");
+         if (ysmPresent) {
+            try {
+               Class<?> entityWithCapsClass = Class.forName("com.elfmcys.yesstevemodel.ooO00oo00o0o0OoO0oO00oO");
+               getCapabilityMethod = entityWithCapsClass.getMethod("oOO0000ooo0oOOo0OO0oo0Oo", Object.class);
+               Class<?> capsClass = Class.forName("com.elfmcys.yesstevemodel.oO000o0O0O0Oo0o00o000oOo.Oo000Oo0oo0oOOOo00oOoOoo");
+               Field capField = capsClass.getDeclaredField("ooO0000oO0o0o0o000Oooo0O");
+               playerAnimatableCap = capField.get(null);
+               Class<?> dataClass = Class.forName("com.elfmcys.yesstevemodel.oO000oOo0OoOOoooooO0oO00");
+               isModelActiveMethod = dataClass.getMethod("OO0o0OOoOOO00OoOoOo0oOOO");
+               
+               Class<?> ysmConfigClass = Class.forName("com.elfmcys.yesstevemodel.oO0oo0oooOo0O0ooooOOooOo");
+               disableSelfModelValue = ysmConfigClass.getDeclaredField("O0OOoooOOOO0oo0o0OoO0oO0").get(null);
+               disableOtherModelValue = ysmConfigClass.getDeclaredField("oOO0ooO00OOooOO0oOo0oO0O").get(null);
+               disableSelfHandsValue = ysmConfigClass.getDeclaredField("Oo0OoOO000OooOoooOoo0ooO").get(null);
+
+               if (disableSelfModelValue != null) {
+                  booleanValueGetMethod = disableSelfModelValue.getClass().getMethod("get");
+               }
+            } catch (Exception e) {
+               System.err.println("[MMDSkin] Failed to initialize YSM Fabric compatibility: " + e.getMessage());
+               ysmPresent = false;
+            }
+         }
+
+         ysmChecked = true;
+      }
+
+      if (ysmPresent && getCapabilityMethod != null && playerAnimatableCap != null && isModelActiveMethod != null) {
+         try {
+            Object optional = getCapabilityMethod.invoke(entity, playerAnimatableCap);
+            if (optional != null) {
+               Method isPresentMethod = optional.getClass().getMethod("isPresent");
+               if ((Boolean) isPresentMethod.invoke(optional)) {
+                  Method getMethod = optional.getClass().getMethod("get");
+                  Object data = getMethod.invoke(optional);
+                  if (data != null) {
+                     return (Boolean) isModelActiveMethod.invoke(data);
+                  }
+               }
+            }
+         } catch (Exception e) {
+            // 忽略调用异常
+         }
+      }
+
+      return false;
+   }
+
+   public static boolean isDisableSelfModel() {
+      return getBooleanValue(disableSelfModelValue);
+   }
+
+   public static boolean isDisableOtherModel() {
+      return getBooleanValue(disableOtherModelValue);
+   }
+
+   public static boolean isDisableSelfHands() {
+      return getBooleanValue(disableSelfHandsValue);
+   }
+
+   private static boolean getBooleanValue(Object valueObj) {
+      if (ysmPresent && valueObj != null && booleanValueGetMethod != null) {
+         try {
+            return (Boolean) booleanValueGetMethod.invoke(valueObj);
+         } catch (Exception e) {
+            return false;
+         }
+      } else {
+         return false;
+      }
+   }
+}

--- a/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/CameraMixin.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/CameraMixin.java
@@ -1,5 +1,8 @@
 package com.shiroha.mmdskin.mixin.fabric;
 
+import com.shiroha.mmdskin.config.ConfigData;
+import com.shiroha.mmdskin.fabric.YsmCompat;
+import com.shiroha.mmdskin.fabric.config.MmdSkinConfig;
 import com.shiroha.mmdskin.renderer.camera.MMDCameraController;
 import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
 import net.minecraft.client.Camera;
@@ -7,6 +10,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,38 +30,54 @@ public abstract class CameraMixin {
     @Shadow
     protected abstract void setRotation(float yaw, float pitch);
 
-    @Inject(method = "setup", at = @At("TAIL"))
+    @Inject(method = "setup(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/world/entity/Entity;ZZF)V", at = @At("TAIL"))
     private void onSetup(BlockGetter level, Entity entity, boolean detached, boolean mirrored, float partialTick, CallbackInfo ci) {
         // 舞台模式相机接管
         MMDCameraController controller = MMDCameraController.getInstance();
         if (controller.isActive()) {
             controller.checkEscapeKey();
-            if (!controller.isActive()) return;
-            controller.updateCamera();
-            if (!controller.isActive()) return;
-            setPosition(controller.getCameraX(), controller.getCameraY(), controller.getCameraZ());
-            setRotation(controller.getCameraYaw(), controller.getCameraPitch());
-            return;
-        }
+            if (controller.isActive()) {
+                controller.updateCamera();
+                if (controller.isActive()) {
+                    this.setPosition(controller.getCameraX(), controller.getCameraY(), controller.getCameraZ());
+                    this.setRotation(controller.getCameraYaw(), controller.getCameraPitch());
+                }
+            }
+        } else {
+            // 第一人称 MMD 模型相机：跟踪眼睛骨骼动画位置
+            if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid() && !detached) {
+                if (entity instanceof LivingEntity living) {
+                    boolean ysmActive = YsmCompat.isYsmModelActive(living);
+                    boolean ysmDisableSelf = YsmCompat.isDisableSelfModel();
+                    if (ysmActive && !ysmDisableSelf) {
+                        return;
+                    }
+                }
 
-        // 第一人称 MMD 模型相机：跟踪眼睛骨骼动画位置
-        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid() && !detached) {
-            float[] eyeOffset = new float[3];
-            FirstPersonManager.getEyeWorldOffset(eyeOffset);
-            {
-                double px = Mth.lerp(partialTick, entity.xo, entity.getX());
-                double py = Mth.lerp(partialTick, entity.yo, entity.getY());
-                double pz = Mth.lerp(partialTick, entity.zo, entity.getZ());
-                // 模型局部 X/Z 偏移需随玩家身体朝向旋转（与 PlayerRendererMixin 中 bodyYaw 一致）
-                float bodyYaw = (entity instanceof LivingEntity le)
-                    ? Mth.rotLerp(partialTick, le.yBodyRotO, le.yBodyRot)
-                    : Mth.rotLerp(partialTick, entity.yRotO, entity.getYRot());
-                float yawRad = (float) Math.toRadians(bodyYaw);
-                double sinYaw = Mth.sin(yawRad);
-                double cosYaw = Mth.cos(yawRad);
-                double worldOffX = eyeOffset[0] * cosYaw - eyeOffset[2] * sinYaw;
-                double worldOffZ = eyeOffset[0] * sinYaw + eyeOffset[2] * cosYaw;
-                setPosition(px + worldOffX, py + eyeOffset[1], pz + worldOffZ);
+                Vec3 boneEyePos = FirstPersonManager.getRotatedEyePosition(entity, partialTick);
+                float originalYaw = entity.getViewYRot(partialTick);
+                float originalPitch = entity.getViewXRot(partialTick);
+                float lookPitchRad = originalPitch * ((float) Math.PI / 180F);
+                float lookYawRad = originalYaw * ((float) Math.PI / 180F);
+                float cosLookPitch = Mth.cos(lookPitchRad);
+                float sinLookPitch = Mth.sin(lookPitchRad);
+                float cosLookYaw = Mth.cos(lookYawRad);
+                float sinLookYaw = Mth.sin(lookYawRad);
+
+                ConfigData config = MmdSkinConfig.getData();
+                double forwardOffset = config.firstPersonCameraForwardOffset;
+                double verticalOffset = config.firstPersonCameraVerticalOffset;
+
+                double targetX = boneEyePos.x + (double) (sinLookYaw * cosLookPitch * (float) (-forwardOffset));
+                double targetY = boneEyePos.y + (double) (sinLookPitch * (float) (-forwardOffset)) + verticalOffset;
+                double targetZ = boneEyePos.z + (double) (cosLookYaw * cosLookPitch * (float) forwardOffset);
+
+                // 彻底删除碰撞检测，直接设置到目标位置
+                Vec3 finalPos = new Vec3(targetX, targetY, targetZ);
+                FirstPersonManager.setLastCameraPos(finalPos);
+
+                this.setPosition(finalPos.x, finalPos.y, finalPos.z);
+                this.setRotation(originalYaw, originalPitch);
             }
         }
     }

--- a/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/EntityMixin.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/EntityMixin.java
@@ -1,0 +1,86 @@
+package com.shiroha.mmdskin.mixin.fabric;
+
+import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * 实体 Mixin — 修复第一人称下的交互射线起点 (Fabric)
+ * 
+ * 当开启第一人称 MMD 渲染时，相机位置已经移动到了模型眼睛骨骼处。
+ * 为了保持准星指向与实际交互（方块破坏、攻击）一致，
+ * 必须让实体的眼睛位置（交互射线起点）也同步到骨骼位置。
+ */
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+    @Inject(method = "getEyePosition(F)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
+    private void onGetEyePosition(float partialTick, CallbackInfoReturnable<Vec3> cir) {
+        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid()) {
+            Entity entity = (Entity) (Object) this;
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.player != null && mc.player.getUUID().equals(entity.getUUID())) {
+                if (mc.options.getCameraType().isFirstPerson()) {
+                    net.minecraft.client.Camera camera = mc.gameRenderer.getMainCamera();
+                    if (camera.isInitialized() && camera.getEntity() == entity) {
+                        cir.setReturnValue(camera.getPosition());
+                        return;
+                    }
+
+                    // 兜底逻辑：手动计算，防止相机未初始化时崩溃
+                    Vec3 bonePos = FirstPersonManager.getRotatedEyePosition(entity, partialTick);
+                    float originalYaw = entity.getViewYRot(partialTick);
+                    float originalPitch = entity.getViewXRot(partialTick);
+                    float lookPitchRad = originalPitch * ((float) Math.PI / 180F);
+                    float lookYawRad = originalYaw * ((float) Math.PI / 180F);
+                    float cosLookPitch = net.minecraft.util.Mth.cos(lookPitchRad);
+                    float sinLookPitch = net.minecraft.util.Mth.sin(lookPitchRad);
+                    float cosLookYaw = net.minecraft.util.Mth.cos(lookYawRad);
+                    float sinLookYaw = net.minecraft.util.Mth.sin(lookYawRad);
+
+                    com.shiroha.mmdskin.config.ConfigData config = com.shiroha.mmdskin.fabric.config.MmdSkinConfig.getData();
+                    double forwardOffset = config.firstPersonCameraForwardOffset;
+                    double verticalOffset = config.firstPersonCameraVerticalOffset;
+
+                    double targetX = bonePos.x + (double) (sinLookYaw * cosLookPitch * (float) (-forwardOffset));
+                    double targetY = bonePos.y + (double) (sinLookPitch * (float) (-forwardOffset)) + verticalOffset;
+                    double targetZ = bonePos.z + (double) (cosLookYaw * cosLookPitch * (float) forwardOffset);
+
+                    cir.setReturnValue(new Vec3(targetX, targetY, targetZ));
+                    return;
+                }
+
+                // 非第一人称，仅返回骨骼位置
+                cir.setReturnValue(FirstPersonManager.getRotatedEyePosition(entity, partialTick));
+            }
+        }
+    }
+
+    @Inject(method = "getViewVector(F)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
+    private void onGetViewVector(float partialTick, CallbackInfoReturnable<Vec3> cir) {
+        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid()) {
+            Entity entity = (Entity) (Object) this;
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.player != null && mc.player.getUUID().equals(entity.getUUID())) {
+                if (mc.options.getCameraType().isFirstPerson()) {
+                    net.minecraft.client.Camera camera = mc.gameRenderer.getMainCamera();
+                    if (camera.isInitialized() && camera.getEntity() == entity) {
+                        float originalYaw = camera.getYRot();
+                        float originalPitch = camera.getXRot();
+                        float pitchRad = originalPitch * ((float) Math.PI / 180F);
+                        float yawRad = -originalYaw * ((float) Math.PI / 180F);
+                        float cosYaw = net.minecraft.util.Mth.cos(yawRad);
+                        float sinYaw = net.minecraft.util.Mth.sin(yawRad);
+                        float cosPitch = net.minecraft.util.Mth.cos(pitchRad);
+                        float sinPitch = net.minecraft.util.Mth.sin(pitchRad);
+                        cir.setReturnValue(new Vec3((double) (sinYaw * cosPitch), (double) (-sinPitch), (double) (cosYaw * cosPitch)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/ItemInHandRendererMixin.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/ItemInHandRendererMixin.java
@@ -1,10 +1,11 @@
 package com.shiroha.mmdskin.mixin.fabric;
 
-import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.shiroha.mmdskin.fabric.YsmCompat;
+import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.ItemInHandRenderer;
-import net.minecraft.client.renderer.MultiBufferSource;
-import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,11 +21,33 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemInHandRenderer.class)
 public abstract class ItemInHandRendererMixin {
     
-    @Inject(method = "renderHandsWithItems", at = @At("HEAD"), cancellable = true)
-    private void onRenderHandsWithItems(float partialTick, PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource, LocalPlayer player, int packedLight,
-            CallbackInfo ci) {
-        if (FirstPersonManager.isActive()) {
+    @Inject(
+        method = "renderHandsWithItems(FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;Lnet/minecraft/client/player/LocalPlayer;I)V",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onRenderHandsWithItems(float partialTick, PoseStack poseStack, BufferSource bufferSource, LocalPlayer player, int packedLight, CallbackInfo ci) {
+        String playerName = player.getName().getString();
+        String selectedModel = PlayerModelSyncManager.getPlayerModel(player.getUUID(), playerName, true);
+
+        // 检查是否为 MMD 默认/原版模型状态
+        boolean isMmdDefault = selectedModel == null || selectedModel.isEmpty() || selectedModel.equals("默认 (原版渲染)");
+        boolean isMmdActive = !isMmdDefault;
+        boolean isVanilaMmdModel = isMmdActive && (selectedModel.equals("VanilaModel") || selectedModel.equalsIgnoreCase("vanila"));
+
+        // 核心逻辑调整：
+        // 无论 MMD 是否激活，只要 YSM 插件表示“我要渲染手臂”（即 isDisableSelfHands 为 false），
+        // 我们就绝对不能执行 ci.cancel()。
+        if (YsmCompat.isYsmModelActive(player)) {
+            if (YsmCompat.isDisableSelfHands()) {
+                ci.cancel();
+            }
+            return; // 一旦 YSM 接管，MMD 就不再干预手臂渲染（避免冲突）
+        }
+
+        // 如果没有 YSM 接管，则由 MMD 决定：
+        // 只有在选了非原版 MMD 模型时，才取消原版手臂渲染。
+        if (isMmdActive && !isVanilaMmdModel) {
             ci.cancel();
         }
     }

--- a/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/LevelRendererMixin.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/mixin/fabric/LevelRendererMixin.java
@@ -1,9 +1,13 @@
 package com.shiroha.mmdskin.mixin.fabric;
 
+import com.shiroha.mmdskin.fabric.YsmCompat;
 import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
 import com.shiroha.mmdskin.renderer.core.IrisCompat;
+import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
 import net.minecraft.client.Camera;
+import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -19,12 +23,57 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public abstract class LevelRendererMixin {
 
     @Redirect(
-        method = "renderLevel",
+        method = "renderLevel(Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/GameRenderer;Lnet/minecraft/client/renderer/LightTexture;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;)V",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;isDetached()Z", ordinal = 0)
     )
     private boolean onCameraIsDetached(Camera camera) {
         if (FirstPersonManager.shouldRenderFirstPerson() && !IrisCompat.isRenderingShadows()) {
-            return true;
+            // 获取当前选中的模型
+            Entity entity = camera.getEntity();
+            if (entity instanceof AbstractClientPlayer player) {
+                String playerName = player.getName().getString();
+                String selectedModel = PlayerModelSyncManager.getPlayerModel(player.getUUID(), playerName, true);
+
+                // 检查是否为 MMD 默认/原版模型状态
+                boolean isMmdDefault = selectedModel == null || selectedModel.isEmpty() || selectedModel.equals("默认 (原版渲染)");
+                boolean isMmdActive = !isMmdDefault;
+                boolean isVanilaMmdModel = isMmdActive && (selectedModel.equals("VanilaModel") || selectedModel.equalsIgnoreCase("vanila"));
+
+                // 核心逻辑调整：
+                // 1. 如果 YSM 插件处于激活状态
+                if (YsmCompat.isYsmModelActive(player)) {
+                    // 如果 YSM 开启了“阻止自身渲染”，此时用户希望：
+                    // - 渲染 MMD 模型（如果是非原版 MMD 模型）
+                    // - 不产生影子
+                    if (YsmCompat.isDisableSelfModel()) {
+                        if (isMmdActive && !isVanilaMmdModel) {
+                            // 俯角检查：向上看时隐藏模型（防止看到后脑勺）
+                            if (camera.getXRot() < 0) {
+                                return false;
+                            }
+                            // 此时我们需要返回 true 来让渲染流跑进 PlayerRenderer，
+                            // 但在 PlayerRendererMixin 里我们会拦截掉原版，只画 MMD。
+                            return true;
+                        }
+                        // 如果是原版 MMD 模型且开启了阻止渲染，则彻底隐藏
+                        return false;
+                    } else {
+                        // 如果 YSM 关闭了“阻止自身渲染”，用户希望：
+                        // - 渲染 YSM 模型（不渲染 MMD）
+                        // - 不在第一人称渲染（YSM 自己的逻辑会处理），且不要产生影子
+                        // 为了不要产生影子，在第一人称下我们应该返回 false 让原版剔除实体
+                        return false;
+                    }
+                }
+
+                // 2. 如果没有 YSM，再由 MMD 决定：
+                if (isMmdActive && !isVanilaMmdModel) {
+                    if (camera.getXRot() < 0) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
         }
         return camera.isDetached();
     }

--- a/fabric/src/main/resources/mmdskin-fabric.mixins.json
+++ b/fabric/src/main/resources/mmdskin-fabric.mixins.json
@@ -13,7 +13,8 @@
     "LevelRendererMixin",
     "ItemInHandRendererMixin",
     "MinecraftMixin",
-    "MouseHandlerMixin"
+    "MouseHandlerMixin",
+    "EntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/CameraMixin.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/CameraMixin.java
@@ -1,5 +1,8 @@
 package com.shiroha.mmdskin.mixin.neoforge;
 
+import com.shiroha.mmdskin.config.ConfigData;
+import com.shiroha.mmdskin.neoforge.YsmCompat;
+import com.shiroha.mmdskin.neoforge.config.MmdSkinConfig;
 import com.shiroha.mmdskin.renderer.camera.MMDCameraController;
 import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
 import net.minecraft.client.Camera;
@@ -7,6 +10,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,37 +30,54 @@ public abstract class CameraMixin {
     @Shadow
     protected abstract void setRotation(float yaw, float pitch);
 
-    @Inject(method = "setup", at = @At("TAIL"))
+    @Inject(method = "setup(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/world/entity/Entity;ZZF)V", at = @At("TAIL"))
     private void onSetup(BlockGetter level, Entity entity, boolean detached, boolean mirrored, float partialTick, CallbackInfo ci) {
         // 舞台模式相机接管
         MMDCameraController controller = MMDCameraController.getInstance();
         if (controller.isActive()) {
             controller.checkEscapeKey();
-            if (!controller.isActive()) return;
-            controller.updateCamera();
-            if (!controller.isActive()) return;
-            setPosition(controller.getCameraX(), controller.getCameraY(), controller.getCameraZ());
-            setRotation(controller.getCameraYaw(), controller.getCameraPitch());
-            return;
-        }
+            if (controller.isActive()) {
+                controller.updateCamera();
+                if (controller.isActive()) {
+                    this.setPosition(controller.getCameraX(), controller.getCameraY(), controller.getCameraZ());
+                    this.setRotation(controller.getCameraYaw(), controller.getCameraPitch());
+                }
+            }
+        } else {
+            // 第一人称 MMD 模型相机：跟踪眼睛骨骼动画位置
+            if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid() && !detached) {
+                if (entity instanceof LivingEntity living) {
+                    boolean ysmActive = YsmCompat.isYsmModelActive(living);
+                    boolean ysmDisableSelf = YsmCompat.isDisableSelfModel();
+                    if (ysmActive && !ysmDisableSelf) {
+                        return;
+                    }
+                }
 
-        // 第一人称 MMD 模型相机：跟踪眼睛骨骼动画位置
-        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid() && !detached) {
-            float[] eyeOffset = new float[3];
-            FirstPersonManager.getEyeWorldOffset(eyeOffset);
-            {
-                double px = Mth.lerp(partialTick, entity.xo, entity.getX());
-                double py = Mth.lerp(partialTick, entity.yo, entity.getY());
-                double pz = Mth.lerp(partialTick, entity.zo, entity.getZ());
-                float bodyYaw = (entity instanceof LivingEntity le)
-                    ? Mth.rotLerp(partialTick, le.yBodyRotO, le.yBodyRot)
-                    : Mth.rotLerp(partialTick, entity.yRotO, entity.getYRot());
-                float yawRad = (float) Math.toRadians(bodyYaw);
-                double sinYaw = Mth.sin(yawRad);
-                double cosYaw = Mth.cos(yawRad);
-                double worldOffX = eyeOffset[0] * cosYaw - eyeOffset[2] * sinYaw;
-                double worldOffZ = eyeOffset[0] * sinYaw + eyeOffset[2] * cosYaw;
-                setPosition(px + worldOffX, py + eyeOffset[1], pz + worldOffZ);
+                Vec3 boneEyePos = FirstPersonManager.getRotatedEyePosition(entity, partialTick);
+                float originalYaw = entity.getViewYRot(partialTick);
+                float originalPitch = entity.getViewXRot(partialTick);
+                float lookPitchRad = originalPitch * ((float) Math.PI / 180F);
+                float lookYawRad = originalYaw * ((float) Math.PI / 180F);
+                float cosLookPitch = Mth.cos(lookPitchRad);
+                float sinLookPitch = Mth.sin(lookPitchRad);
+                float cosLookYaw = Mth.cos(lookYawRad);
+                float sinLookYaw = Mth.sin(lookYawRad);
+
+                ConfigData config = MmdSkinConfig.getData();
+                double forwardOffset = config.firstPersonCameraForwardOffset;
+                double verticalOffset = config.firstPersonCameraVerticalOffset;
+
+                double targetX = boneEyePos.x + (double) (sinLookYaw * cosLookPitch * (float) (-forwardOffset));
+                double targetY = boneEyePos.y + (double) (sinLookPitch * (float) (-forwardOffset)) + verticalOffset;
+                double targetZ = boneEyePos.z + (double) (cosLookYaw * cosLookPitch * (float) forwardOffset);
+
+                // 彻底删除碰撞检测，直接设置到目标位置
+                Vec3 finalPos = new Vec3(targetX, targetY, targetZ);
+                FirstPersonManager.setLastCameraPos(finalPos);
+
+                this.setPosition(finalPos.x, finalPos.y, finalPos.z);
+                this.setRotation(originalYaw, originalPitch);
             }
         }
     }

--- a/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/EntityMixin.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/EntityMixin.java
@@ -1,0 +1,84 @@
+package com.shiroha.mmdskin.mixin.neoforge;
+
+import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Entity Mixin — 第一人称视线同步
+ * 
+ * 修正第一人称模式下实体眼睛位置和视向量。
+ * 这对于解决十字准星交互偏移至关重要。
+ */
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+    @Inject(method = "getEyePosition(F)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
+    private void onGetEyePosition(float partialTick, CallbackInfoReturnable<Vec3> cir) {
+        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid()) {
+            Entity entity = (Entity) (Object) this;
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.player != null && mc.player.getUUID().equals(entity.getUUID())) {
+                if (mc.options.getCameraType().isFirstPerson()) {
+                    net.minecraft.client.Camera camera = mc.gameRenderer.getMainCamera();
+                    if (camera.isInitialized() && camera.getEntity() == entity) {
+                        cir.setReturnValue(camera.getPosition());
+                        return;
+                    }
+
+                    // 兜底逻辑：手动计算，防止相机未初始化时崩溃
+                    Vec3 bonePos = FirstPersonManager.getRotatedEyePosition(entity, partialTick);
+                    float originalYaw = entity.getViewYRot(partialTick);
+                    float originalPitch = entity.getViewXRot(partialTick);
+                    float lookPitchRad = originalPitch * ((float) Math.PI / 180F);
+                    float lookYawRad = originalYaw * ((float) Math.PI / 180F);
+                    float cosLookPitch = net.minecraft.util.Mth.cos(lookPitchRad);
+                    float sinLookPitch = net.minecraft.util.Mth.sin(lookPitchRad);
+                    float cosLookYaw = net.minecraft.util.Mth.cos(lookYawRad);
+                    float sinLookYaw = net.minecraft.util.Mth.sin(lookYawRad);
+
+                    com.shiroha.mmdskin.config.ConfigData config = com.shiroha.mmdskin.neoforge.config.MmdSkinConfig.getData();
+                    double forwardOffset = config.firstPersonCameraForwardOffset;
+                    double verticalOffset = config.firstPersonCameraVerticalOffset;
+
+                    double targetX = bonePos.x + (double) (sinLookYaw * cosLookPitch * (float) (-forwardOffset));
+                    double targetY = bonePos.y + (double) (sinLookPitch * (float) (-forwardOffset)) + verticalOffset;
+                    double targetZ = bonePos.z + (double) (cosLookYaw * cosLookPitch * (float) forwardOffset);
+
+                    cir.setReturnValue(new Vec3(targetX, targetY, targetZ));
+                    return;
+                }
+
+                cir.setReturnValue(FirstPersonManager.getRotatedEyePosition(entity, partialTick));
+            }
+        }
+    }
+
+    @Inject(method = "getViewVector(F)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
+    private void onGetViewVector(float partialTick, CallbackInfoReturnable<Vec3> cir) {
+        if (FirstPersonManager.isActive() && FirstPersonManager.isEyeBoneValid()) {
+            Entity entity = (Entity) (Object) this;
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.player != null && mc.player.getUUID().equals(entity.getUUID())) {
+                if (mc.options.getCameraType().isFirstPerson()) {
+                    net.minecraft.client.Camera camera = mc.gameRenderer.getMainCamera();
+                    if (camera.isInitialized() && camera.getEntity() == entity) {
+                        float originalYaw = camera.getYRot();
+                        float originalPitch = camera.getXRot();
+                        float pitchRad = originalPitch * ((float) Math.PI / 180F);
+                        float yawRad = -originalYaw * ((float) Math.PI / 180F);
+                        float cosYaw = net.minecraft.util.Mth.cos(yawRad);
+                        float sinYaw = net.minecraft.util.Mth.sin(yawRad);
+                        float cosPitch = net.minecraft.util.Mth.cos(pitchRad);
+                        float sinPitch = net.minecraft.util.Mth.sin(pitchRad);
+                        cir.setReturnValue(new Vec3((double) (sinYaw * cosPitch), (double) (-sinPitch), (double) (cosYaw * cosPitch)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/ItemInHandRendererMixin.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/ItemInHandRendererMixin.java
@@ -1,10 +1,11 @@
 package com.shiroha.mmdskin.mixin.neoforge;
 
-import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.shiroha.mmdskin.neoforge.YsmCompat;
+import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.ItemInHandRenderer;
-import net.minecraft.client.renderer.MultiBufferSource;
-import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,11 +19,33 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemInHandRenderer.class)
 public abstract class ItemInHandRendererMixin {
     
-    @Inject(method = "renderHandsWithItems", at = @At("HEAD"), cancellable = true)
-    private void onRenderHandsWithItems(float partialTick, PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource, LocalPlayer player, int packedLight,
-            CallbackInfo ci) {
-        if (FirstPersonManager.isActive()) {
+    @Inject(
+        method = "renderHandsWithItems(FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;Lnet/minecraft/client/player/LocalPlayer;I)V",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onRenderHandsWithItems(float partialTick, PoseStack poseStack, BufferSource bufferSource, LocalPlayer player, int packedLight, CallbackInfo ci) {
+        String playerName = player.getName().getString();
+        String selectedModel = PlayerModelSyncManager.getPlayerModel(player.getUUID(), playerName, true);
+        
+        // 检查是否为 MMD 默认/原版模型状态
+        boolean isMmdDefault = selectedModel == null || selectedModel.isEmpty() || selectedModel.equals("默认 (原版渲染)");
+        boolean isMmdActive = !isMmdDefault;
+        boolean isVanilaMmdModel = isMmdActive && (selectedModel.equals("VanilaModel") || selectedModel.equalsIgnoreCase("vanila"));
+
+        // 核心逻辑调整：
+        // 无论 MMD 是否激活，只要 YSM 插件表示“我要渲染手臂”（即 isDisableSelfHands 为 false），
+        // 我们就绝对不能执行 ci.cancel()。
+        if (YsmCompat.isYsmModelActive(player)) {
+            if (YsmCompat.isDisableSelfHands()) {
+                ci.cancel();
+            }
+            return; // 一旦 YSM 接管，MMD 就不再干预手臂渲染（避免冲突）
+        }
+
+        // 如果没有 YSM 接管，则由 MMD 决定：
+        // 只有在选了非原版 MMD 模型时，才取消原版手臂渲染。
+        if (isMmdActive && !isVanilaMmdModel) {
             ci.cancel();
         }
     }

--- a/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/LevelRendererMixin.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/mixin/neoforge/LevelRendererMixin.java
@@ -1,9 +1,13 @@
 package com.shiroha.mmdskin.mixin.neoforge;
 
+import com.shiroha.mmdskin.neoforge.YsmCompat;
 import com.shiroha.mmdskin.renderer.core.FirstPersonManager;
 import com.shiroha.mmdskin.renderer.core.IrisCompat;
+import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
 import net.minecraft.client.Camera;
+import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -19,12 +23,57 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public abstract class LevelRendererMixin {
 
     @Redirect(
-        method = "renderLevel",
+        method = "renderLevel(Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/GameRenderer;Lnet/minecraft/client/renderer/LightTexture;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;)V",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;isDetached()Z", ordinal = 0)
     )
     private boolean onCameraIsDetached(Camera camera) {
         if (FirstPersonManager.shouldRenderFirstPerson() && !IrisCompat.isRenderingShadows()) {
-            return true;
+            // 获取当前选中的模型
+            Entity entity = camera.getEntity();
+            if (entity instanceof AbstractClientPlayer player) {
+                String playerName = player.getName().getString();
+                String selectedModel = PlayerModelSyncManager.getPlayerModel(player.getUUID(), playerName, true);
+
+                // 检查是否为 MMD 默认/原版模型状态
+                boolean isMmdDefault = selectedModel == null || selectedModel.isEmpty() || selectedModel.equals("默认 (原版渲染)");
+                boolean isMmdActive = !isMmdDefault;
+                boolean isVanilaMmdModel = isMmdActive && (selectedModel.equals("VanilaModel") || selectedModel.equalsIgnoreCase("vanila"));
+
+                // 核心逻辑调整：
+                // 1. 如果 YSM 插件处于激活状态
+                if (YsmCompat.isYsmModelActive(player)) {
+                    // 如果 YSM 开启了“阻止自身渲染”，此时用户希望：
+                    // - 渲染 MMD 模型（如果是非原版 MMD 模型）
+                    // - 不产生影子
+                    if (YsmCompat.isDisableSelfModel()) {
+                        if (isMmdActive && !isVanilaMmdModel) {
+                            // 俯角检查：向上看时隐藏模型（防止看到后脑勺）
+                            if (camera.getXRot() < 0) {
+                                return false;
+                            }
+                            // 此时我们需要返回 true 来让渲染流跑进 PlayerRenderer，
+                            // 但在 PlayerRendererMixin 里我们会拦截掉原版，只画 MMD。
+                            return true;
+                        }
+                        // 如果是原版 MMD 模型且开启了阻止渲染，则彻底隐藏
+                        return false;
+                    } else {
+                        // 如果 YSM 关闭了“阻止自身渲染”，用户希望：
+                        // - 渲染 YSM 模型（不渲染 MMD）
+                        // - 不在第一人称渲染（YSM 自己的逻辑会处理），且不要产生影子
+                        // 为了不要产生影子，在第一人称下我们应该返回 false 让原版剔除实体
+                        return false;
+                    }
+                }
+
+                // 2. 如果没有 YSM，再由 MMD 决定：
+                if (isMmdActive && !isVanilaMmdModel) {
+                    if (camera.getXRot() < 0) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
         }
         return camera.isDetached();
     }

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/MmdSkinNeoForge.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/MmdSkinNeoForge.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.shiroha.mmdskin.MmdSkin;
+import com.shiroha.mmdskin.neoforge.register.MmdSkinAttachments;
 import com.shiroha.mmdskin.neoforge.register.MmdSkinRegisterCommon;
 
 import net.neoforged.bus.api.IEventBus;
@@ -17,6 +18,7 @@ public class MmdSkinNeoForge {
     public MmdSkinNeoForge(IEventBus modEventBus) {
         modEventBus.addListener(this::preInit);
         modEventBus.addListener(MmdSkinRegisterCommon::onRegisterPayloadHandlers);
+        MmdSkinAttachments.ATTACHMENT_TYPES.register(modEventBus);
     }
 
     public void preInit(FMLCommonSetupEvent event) {

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/MmdSkinNeoForgeClient.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/MmdSkinNeoForgeClient.java
@@ -4,6 +4,7 @@ import com.shiroha.mmdskin.MmdSkin;
 import com.shiroha.mmdskin.MmdSkinClient;
 import com.shiroha.mmdskin.neoforge.config.MmdSkinConfig;
 import com.shiroha.mmdskin.neoforge.maid.MaidRenderEventHandler;
+import com.shiroha.mmdskin.neoforge.maid.MaidSyncEventHandler;
 import com.shiroha.mmdskin.neoforge.register.MmdSkinRegisterClient;
 import com.shiroha.mmdskin.renderer.model.MMDModelOpenGL;
 
@@ -58,6 +59,7 @@ public class MmdSkinNeoForgeClient {
         
         // 注册女仆渲染事件处理器（TouhouLittleMaid 联动）
         NeoForge.EVENT_BUS.register(new MaidRenderEventHandler());
+        NeoForge.EVENT_BUS.register(MaidSyncEventHandler.class);
         
         MmdSkinClient.logger.info("MMD Skin NeoForge 客户端初始化成功");
     }

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/YsmCompat.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/YsmCompat.java
@@ -1,0 +1,113 @@
+package com.shiroha.mmdskin.neoforge;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.attachment.AttachmentType;
+
+/**
+ * YSM (Yes Steve Model) 兼容逻辑 - NeoForge 版
+ * 通过反射访问 YSM 的数据和配置，用于在第一人称模式下协调渲染
+ */
+public class YsmCompat {
+   private static boolean ysmChecked = false;
+   private static boolean ysmPresent = false;
+   private static AttachmentType<?> ysmAttachmentType = null;
+   private static Method isModelActiveMethod = null;
+   private static Object disableSelfModelValue = null;
+   private static Object disableOtherModelValue = null;
+   private static Object disableSelfHandsValue = null;
+   private static Method booleanValueGetMethod = null;
+
+   /**
+    * 判断实体是否应当显示 YSM 模型（而非原版/MMD）
+    */
+   public static boolean isYsmActive(LivingEntity entity) {
+      if (!isYsmModelActive(entity)) {
+         return false;
+      }
+      
+      Minecraft mc = Minecraft.getInstance();
+      boolean isLocalPlayer = mc.player != null && mc.player.getUUID().equals(entity.getUUID());
+      if (isLocalPlayer) {
+         return !isDisableSelfModel();
+      } else {
+         return !isDisableOtherModel();
+      }
+   }
+
+   /**
+    * 判断实体是否配置了 YSM 模型（无论当前是否显示）
+    */
+   public static boolean isYsmModelActive(LivingEntity entity) {
+      if (!ysmChecked) {
+         ysmPresent = ModList.get().isLoaded("yes_steve_model");
+         if (ysmPresent) {
+            try {
+               // 反射获取 YSM 核心数据类和字段 (针对 1.21.1 混淆名)
+               Class<?> ysmDataClass = Class.forName("com.elfmcys.yesstevemodel.oOooO0OoOoOO0OoOo0o00OoO");
+               Field typeField = ysmDataClass.getDeclaredField("ooO0000oO0o0o0o000Oooo0O");
+               ysmAttachmentType = (AttachmentType<?>)typeField.get(null);
+               isModelActiveMethod = ysmDataClass.getMethod("OO0o0OOoOOO00OoOoOo0oOOO");
+               
+               // 反射获取 YSM 配置类和配置项
+               Class<?> ysmConfigClass = Class.forName("com.elfmcys.yesstevemodel.oO0oo0oooOo0O0ooooOOooOo");
+               disableSelfModelValue = ysmConfigClass.getDeclaredField("O0OOoooOOOO0oo0o0OoO0oO0").get(null);
+               disableOtherModelValue = ysmConfigClass.getDeclaredField("oOO0ooO00OOooOO0oOo0oO0O").get(null);
+               disableSelfHandsValue = ysmConfigClass.getDeclaredField("Oo0OoOO000OooOoooOoo0ooO").get(null);
+
+               if (disableSelfModelValue != null) {
+                  booleanValueGetMethod = disableSelfModelValue.getClass().getMethod("get");
+               }
+            } catch (Exception e) {
+               System.err.println("[MMDSkin] Failed to initialize YSM compatibility: " + e.getMessage());
+               ysmPresent = false;
+            }
+         }
+
+         ysmChecked = true;
+      }
+
+      if (ysmPresent && ysmAttachmentType != null && isModelActiveMethod != null) {
+         try {
+            Object data = entity.getData(ysmAttachmentType);
+            if (data != null) {
+               return (Boolean) isModelActiveMethod.invoke(data);
+            }
+         } catch (Exception e) {
+            // 忽略调用异常
+         }
+      }
+
+      return false;
+   }
+
+   /** 获取 YSM 是否开启了“阻止自身模型渲染” */
+   public static boolean isDisableSelfModel() {
+      return getBooleanValue(disableSelfModelValue);
+   }
+
+   /** 获取 YSM 是否开启了“阻止其他玩家模型渲染” */
+   public static boolean isDisableOtherModel() {
+      return getBooleanValue(disableOtherModelValue);
+   }
+
+   /** 获取 YSM 是否开启了“阻止自身手臂渲染” */
+   public static boolean isDisableSelfHands() {
+      return getBooleanValue(disableSelfHandsValue);
+   }
+
+   private static boolean getBooleanValue(Object valueObj) {
+      if (ysmPresent && valueObj != null && booleanValueGetMethod != null) {
+         try {
+            return (Boolean) booleanValueGetMethod.invoke(valueObj);
+         } catch (Exception e) {
+            return false;
+         }
+      } else {
+         return false;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/maid/MaidSyncEventHandler.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/maid/MaidSyncEventHandler.java
@@ -1,0 +1,30 @@
+package com.shiroha.mmdskin.neoforge.maid;
+
+import com.shiroha.mmdskin.neoforge.network.MmdSkinNetworkPack;
+import com.shiroha.mmdskin.neoforge.register.MmdSkinAttachments;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent.StartTracking;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+/**
+ * NeoForge 女仆模型同步事件处理器
+ */
+@EventBusSubscriber(modid = "mmdskin")
+public class MaidSyncEventHandler {
+    @SubscribeEvent
+    public static void onStartTracking(StartTracking event) {
+        Entity target = event.getTarget();
+        ServerPlayer player = (ServerPlayer) event.getEntity();
+        if (target.hasData(MmdSkinAttachments.MAID_MMD_MODEL.get())) {
+            String modelName = target.getData(MmdSkinAttachments.MAID_MMD_MODEL.get());
+            if (modelName != null && !modelName.isEmpty()) {
+                MmdSkinNetworkPack syncPack = MmdSkinNetworkPack.forMaid(4, player.getUUID(), target.getId(), modelName);
+                PacketDistributor.sendToPlayer(player, syncPack);
+            }
+        }
+    }
+}

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/network/MmdSkinNetworkPack.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/network/MmdSkinNetworkPack.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import com.shiroha.mmdskin.MmdSkin;
 import com.shiroha.mmdskin.maid.MaidMMDModelManager;
+import com.shiroha.mmdskin.neoforge.register.MmdSkinAttachments;
 import com.shiroha.mmdskin.renderer.render.MmdSkinRendererPlayerHelper;
 import com.shiroha.mmdskin.ui.network.PlayerModelSyncManager;
 import net.minecraft.client.Minecraft;
@@ -49,7 +50,7 @@ public record MmdSkinNetworkPack(int opCode, UUID playerUUID, String animId, int
     private static void encode(FriendlyByteBuf buffer, MmdSkinNetworkPack pack) {
         buffer.writeInt(pack.opCode);
         buffer.writeUUID(pack.playerUUID);
-        if (pack.opCode == 1 || pack.opCode == 3 || pack.opCode == 6 || pack.opCode == 7 || pack.opCode == 8) {
+        if (pack.opCode == 1 || pack.opCode == 3 || pack.opCode == 6 || pack.opCode == 7 || pack.opCode == 8 || pack.opCode == 9) {
             buffer.writeUtf(pack.animId);
         } else if (pack.opCode == 4 || pack.opCode == 5) {
             buffer.writeInt(pack.arg0);
@@ -58,14 +59,14 @@ public record MmdSkinNetworkPack(int opCode, UUID playerUUID, String animId, int
             buffer.writeInt(pack.arg0);
         }
     }
-    
+
     private static MmdSkinNetworkPack decode(FriendlyByteBuf buffer) {
         int opCode = buffer.readInt();
         UUID playerUUID = buffer.readUUID();
         String animId = "";
         int arg0 = 0;
-        
-        if (opCode == 1 || opCode == 3 || opCode == 6 || opCode == 7 || opCode == 8) {
+
+        if (opCode == 1 || opCode == 3 || opCode == 6 || opCode == 7 || opCode == 8 || opCode == 9) {
             animId = buffer.readUtf();
         } else if (opCode == 4 || opCode == 5) {
             arg0 = buffer.readInt();
@@ -84,11 +85,32 @@ public record MmdSkinNetworkPack(int opCode, UUID playerUUID, String animId, int
     public static void handle(MmdSkinNetworkPack pack, IPayloadContext ctx) {
         ctx.enqueueWork(() -> {
             if (ctx.player() instanceof ServerPlayer sender) {
-                // 服务器端（含局域网）：转发给除发送者外的所有客户端
-                for (ServerPlayer player : sender.getServer().getPlayerList().getPlayers()) {
-                    if (!player.equals(sender)) {
-                        PacketDistributor.sendToPlayer(player, pack);
+                // opCode 10: 客户端请求所有玩家的模型同步
+                if (pack.opCode == 10) {
+                    for (ServerPlayer player : sender.getServer().getPlayerList().getPlayers()) {
+                        String modelName = player.getData(MmdSkinAttachments.PLAYER_MMD_MODEL.get());
+                        if (modelName != null && !modelName.isEmpty()) {
+                            PacketDistributor.sendToPlayer(sender, MmdSkinNetworkPack.withAnimId(3, player.getUUID(), modelName));
+                        }
                     }
+                    return;
+                }
+
+                if (pack.opCode == 4) {
+                    Entity entity = sender.level().getEntity(pack.arg0);
+                    if (entity != null) {
+                        entity.setData(MmdSkinAttachments.MAID_MMD_MODEL.get(), pack.animId);
+                    }
+                }
+
+                // opCode 3: 模型变更，存入附件系统
+                if (pack.opCode == 3) {
+                    sender.setData(MmdSkinAttachments.PLAYER_MMD_MODEL.get(), pack.animId);
+                }
+
+                // 服务器端（含局域网）：转发给所有客户端（包括发送者，以便同步状态）
+                for (ServerPlayer player : sender.getServer().getPlayerList().getPlayers()) {
+                    PacketDistributor.sendToPlayer(player, pack);
                 }
             } else {
                 // 客户端：处理收到的包
@@ -99,32 +121,59 @@ public record MmdSkinNetworkPack(int opCode, UUID playerUUID, String animId, int
     
     private void handleClient() {
         Minecraft mc = Minecraft.getInstance();
-        if (mc.player == null || playerUUID.equals(mc.player.getUUID())) {
-            return;
-        }
-        
-        if (mc.level == null) return;
-        Player target = mc.level.getPlayerByUUID(playerUUID);
-
-        switch (opCode) {
-            case 1 -> { if (target != null) MmdSkinRendererPlayerHelper.CustomAnim(target, animId); }
-            case 2 -> { if (target != null) MmdSkinRendererPlayerHelper.ResetPhysics(target); }
-            case 3 -> PlayerModelSyncManager.onRemotePlayerModelReceived(playerUUID, animId);
-            case 4 -> {
-                Entity maidEntity = mc.level.getEntity(arg0);
-                if (maidEntity != null) {
-                    MaidMMDModelManager.bindModel(maidEntity.getUUID(), animId);
+        if (mc.player != null) {
+            if (this.opCode == 4 || this.opCode == 5 || !this.playerUUID.equals(mc.player.getUUID())) {
+                if (mc.level != null) {
+                    Player target = mc.level.getPlayerByUUID(this.playerUUID);
+                    switch (this.opCode) {
+                        case 1:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.CustomAnim(target, this.animId);
+                            }
+                            break;
+                        case 2:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.ResetPhysics(target);
+                            }
+                            break;
+                        case 3:
+                            PlayerModelSyncManager.onRemotePlayerModelReceived(this.playerUUID, this.animId);
+                            break;
+                        case 4:
+                            Entity maidEntityx = mc.level.getEntity(this.arg0);
+                            if (maidEntityx != null) {
+                                MaidMMDModelManager.bindModel(maidEntityx.getUUID(), this.animId);
+                            }
+                            break;
+                        case 5:
+                            Entity maidEntity = mc.level.getEntity(this.arg0);
+                            if (maidEntity != null) {
+                                MaidMMDModelManager.playAnimation(maidEntity.getUUID(), this.animId);
+                            }
+                            break;
+                        case 6:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.RemoteMorph(target, this.animId);
+                            }
+                            break;
+                        case 7:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.StageAnimStart(target, this.animId);
+                            }
+                            break;
+                        case 8:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.StageAnimEnd(target);
+                            }
+                            break;
+                        case 9:
+                            if (target != null) {
+                                MmdSkinRendererPlayerHelper.StageAudioPlay(target, this.animId);
+                            }
+                            break;
+                    }
                 }
             }
-            case 5 -> {
-                Entity maidEntity = mc.level.getEntity(arg0);
-                if (maidEntity != null) {
-                    MaidMMDModelManager.playAnimation(maidEntity.getUUID(), animId);
-                }
-            }
-            case 7 -> { if (target != null) MmdSkinRendererPlayerHelper.StageAnimStart(target, animId); }
-            case 8 -> { if (target != null) MmdSkinRendererPlayerHelper.StageAnimEnd(target); }
-            case 6 -> { if (target != null) MmdSkinRendererPlayerHelper.RemoteMorph(target, animId); }
         }
     }
 }

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/register/MmdSkinAttachments.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/register/MmdSkinAttachments.java
@@ -1,0 +1,25 @@
+package com.shiroha.mmdskin.neoforge.register;
+
+import com.mojang.serialization.Codec;
+import java.util.function.Supplier;
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+/**
+ * NeoForge 数据附件注册
+ * 用于在实体上存储 MMD 模型信息，支持自动同步和持久化
+ */
+public class MmdSkinAttachments {
+    public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, "mmdskin");
+
+    /** 存储女仆实体的 MMD 模型名称 */
+    public static final Supplier<AttachmentType<String>> MAID_MMD_MODEL = ATTACHMENT_TYPES.register(
+            "maid_mmd_model", () -> AttachmentType.builder(() -> "").serialize(Codec.STRING).build()
+    );
+
+    /** 存储玩家实体的 MMD 模型名称（用于服务端持久化和同步） */
+    public static final Supplier<AttachmentType<String>> PLAYER_MMD_MODEL = ATTACHMENT_TYPES.register(
+            "player_mmd_model", () -> AttachmentType.builder(() -> "").serialize(Codec.STRING).build()
+    );
+}

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/register/MmdSkinRegisterClient.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/register/MmdSkinRegisterClient.java
@@ -276,6 +276,8 @@ public class MmdSkinRegisterClient {
                     logger.info("玩家加入服务器，广播模型选择: {}", selectedModel);
                     PlayerModelSyncManager.broadcastLocalModelSelection(mc.player.getUUID(), selectedModel);
                 }
+                // 请求所有玩家的模型信息
+                PacketDistributor.sendToServer(MmdSkinNetworkPack.withAnimId(10, mc.player.getUUID(), ""));
             }
         }
         

--- a/neoforge/src/main/resources/mmdskin-neoforge.mixins.json
+++ b/neoforge/src/main/resources/mmdskin-neoforge.mixins.json
@@ -12,7 +12,8 @@
     "LevelRendererMixin",
     "ItemInHandRendererMixin",
     "MinecraftMixin",
-    "MouseHandlerMixin"
+    "MouseHandlerMixin",
+    "EntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
增加了对YSM的兼容（打开YSM“阻止渲染自身玩家模型”时会才接管自身模型渲染，其他玩家同理） #14 
女仆MMD模型现在对所有人可见且持久化
修复进入较早的玩家模型无法被后续进入玩家渲染的问题
修复跳舞时音乐无法被其他玩家听到以及中途退出动作无法停止的问题
修复 #19  第一人称模型渲染十字准星偏移及穿模（绑定模型眼部，摄像机偏移可在模组设置中根据模型自行配置）
修复在某些情况下模型渲染异常的问题
修复在旁观模式下也渲染MMD模型的问题
在 NeoForge 平台上测试通过 Fabric 暂未测试