### PR TITLE
修改安卓libc++查找逻辑

### DIFF
--- a/common/src/main/java/com/shiroha/mmdskin/NativeLibraryLoader.java
+++ b/common/src/main/java/com/shiroha/mmdskin/NativeLibraryLoader.java
@@ -327,37 +327,27 @@ public final class NativeLibraryLoader {
         String fclLibs = System.getenv("FCL_NATIVEDIR");
         String javaLib = System.getProperty("java.home") + "/lib";
 
-        var dirsToSearch = new java.util.ArrayList<Path>();
+        var dirsToSearch = new java.util.ArrayList<File>();
         if (libPaths != null && !libPaths.isEmpty()) {
             for (String part : libPaths.split(":")) {
                 if (!part.isEmpty()) {
-                    dirsToSearch.add(Paths.get(part));
+                    dirsToSearch.add(new File(part));
                 }
             }
         }
         if (pojavLibs != null && !pojavLibs.isEmpty()) {
-            dirsToSearch.add(Paths.get(pojavLibs));
+            dirsToSearch.add(new File(pojavLibs));
         }
         if (fclLibs != null && !fclLibs.isEmpty()) {
-            dirsToSearch.add(Paths.get(fclLibs));
+            dirsToSearch.add(new File(fclLibs));
         }
-        dirsToSearch.add(Paths.get(javaLib));
+        dirsToSearch.add(new File(javaLib));
 
-        for (Path dir : dirsToSearch) {
-            try {
-                if (!Files.exists(dir) || !Files.isDirectory(dir)) continue;
-                try (var stream = Files.find(dir, Integer.MAX_VALUE,
-                        (p, attr) -> attr.isRegularFile() && !attr.isSymbolicLink()
-                                && p.getFileName().toString().equals(libcName))) {
-                    var first = stream.findFirst();
-                    if (first.isPresent()) {
-                        return first.get().toAbsolutePath().toString();
-                    }
-                }
-            } catch (IOException e) {
-                logger.warn("[Android] 查找 libc++_shared.so 库时发生错误: " + dir + " -> " + e.getMessage());
-            }
-        }
+        for (var dir : dirsToSearch)
+            if (dir.isDirectory() && dir.isAbsolute() && dir.canRead())
+                for (var file : dir.listFiles())
+                    if (file.getName().equals(libcName) && file.isFile())
+                        return file.getAbsolutePath();
         return null;
     }
 


### PR DESCRIPTION
之前的逻辑会出现报错导致安卓加载出现下面错误，但是我模拟器权限跟手机不一样，没测出来。
现在更改查找逻辑，过滤掉没有读取权限的文件夹。
```
java.lang.RuntimeException: Could not execute entrypoint stage 'client' due to errors, provided by 'mmdskin' at 'com.shiroha.mmdskin.fabric.MmdSkinFabricClient'!
        at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$0(FabricLoaderImpl.java:409)
        at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33)
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:407)
        at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:53)
        at knot//net.minecraft.class_310.<init>(class_310.java:458)
        at knot//net.minecraft.client.main.Main.main(Main.java:211)
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
        at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at mio.Wrapper.main(Wrapper.java:21)
Caused by: java.nio.file.AccessDeniedException: /system/lib64/bootstrap
        at java.base/sun.nio.fs.UnixException.translateToIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(Unknown Source)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(Unknown Source)
        at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(Unknown Source)
        at java.base/java.nio.file.Files.readAttributes(Unknown Source)
        at java.base/java.nio.file.FileTreeWalker.getAttributes(Unknown Source)
        at java.base/java.nio.file.FileTreeWalker.visit(Unknown Source)
        at java.base/java.nio.file.FileTreeWalker.next(Unknown Source)
        at java.base/java.nio.file.FileTreeIterator.fetchNextIfNeeded(Unknown Source)
        at java.base/java.nio.file.FileTreeIterator.hasNext(Unknown Source)
        at java.base/java.util.Spliterators$IteratorSpliterator.tryAdvance(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline.findFirst(Unknown Source)
        at knot//com.shiroha.mmdskin.NativeLibraryLoader.findLibcPath(NativeLibraryLoader.java:352)
        at knot//com.shiroha.mmdskin.NativeLibraryLoader.loadAndroid(NativeLibraryLoader.java:166)
        at knot//com.shiroha.mmdskin.NativeLibraryLoader.loadAndVerify(NativeLibraryLoader.java:90)
        at knot//com.shiroha.mmdskin.NativeFunc.GetInst(NativeFunc.java:16)
        at knot//com.shiroha.mmdskin.renderer.runtime.texture.MMDTextureManager.Init(MMDTextureManager.java:34)
        at knot//com.shiroha.mmdskin.MmdSkinClient.initClient(MmdSkinClient.java:20)
        at knot//com.shiroha.mmdskin.fabric.MmdSkinFabricClient.onInitializeClient(MmdSkinFabricClient.java:18)
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405)
        ... 11 more
```