### PR TITLE
perf: 物理系统+纹理系统性能优化，原生库打包进JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,3 +96,81 @@ subprojects {
 		}
 	}
 }
+
+// ============================================================================
+// Rust 原生引擎编译 & 打包进 JAR
+// ============================================================================
+
+def rustEngineDir = file('rust_engine')
+def nativesResourceDir = file('common/src/main/resources/natives')
+
+/**
+ * 编译 Rust 原生引擎
+ */
+task buildRustEngine {
+	doLast {
+		def cargo = findCargo()
+		logger.lifecycle("[Rust] 使用 cargo: ${cargo}")
+		logger.lifecycle("[Rust] 工作目录: ${rustEngineDir.absolutePath}")
+		def proc = new ProcessBuilder(cargo, 'build', '--release')
+				.directory(rustEngineDir)
+				.redirectErrorStream(true)
+				.start()
+		proc.inputStream.eachLine { line -> logger.lifecycle("[cargo] ${line}") }
+		def exitCode = proc.waitFor()
+		if (exitCode != 0) {
+			throw new GradleException("cargo build --release 失败，退出码: ${exitCode}")
+		}
+		logger.lifecycle("[Rust] 编译完成")
+	}
+}
+
+/**
+ * 将编译产物复制到 common 模块的 resources/natives 目录
+ */
+task copyRustNatives(type: Copy) {
+	dependsOn buildRustEngine
+
+	def osName = System.getProperty('os.name').toLowerCase()
+	def releaseDir = new File(rustEngineDir, 'target/release')
+
+	if (osName.contains('windows')) {
+		from(releaseDir) { include 'mmd_engine.dll' }
+		into new File(nativesResourceDir, 'windows-x64')
+		logger.lifecycle('[Rust] 目标平台: windows-x64')
+	} else if (osName.contains('mac')) {
+		from(releaseDir) { include 'libmmd_engine.dylib' }
+		into new File(nativesResourceDir, 'macos-x64')
+		logger.lifecycle('[Rust] 目标平台: macos-x64')
+	} else if (osName.contains('linux')) {
+		from(releaseDir) { include 'libmmd_engine.so' }
+		into new File(nativesResourceDir, 'linux-x64')
+		logger.lifecycle('[Rust] 目标平台: linux-x64')
+	} else {
+		logger.warn('[Rust] 未知平台，跳过原生库复制: ' + osName)
+	}
+}
+
+// 确保 common 模块处理资源前已完成 Rust 编译和复制
+project(':common').tasks.named('processResources').configure { dependsOn copyRustNatives }
+project(':common').tasks.named('sourcesJar').configure { dependsOn copyRustNatives }
+
+/**
+ * 查找系统上的 cargo 可执行文件
+ */
+static String findCargo() {
+    def isWin = System.getProperty('os.name').toLowerCase().contains('windows')
+    def exeSuffix = isWin ? '.exe' : ''
+    // 1. 环境变量 CARGO_HOME
+    def cargoHome = System.getenv('CARGO_HOME')
+    if (cargoHome) {
+        def exe = new File(cargoHome, "bin/cargo${exeSuffix}")
+        if (exe.exists()) return exe.absolutePath
+    }
+    // 2. ~/.cargo/bin
+    def home = System.getProperty('user.home')
+    def dotCargo = new File(home, ".cargo/bin/cargo${exeSuffix}")
+    if (dotCargo.exists()) return dotCargo.absolutePath
+    // 3. 直接依赖 PATH
+    return 'cargo'
+}

--- a/common/src/main/java/com/shiroha/mmdskin/NativeLibraryLoader.java
+++ b/common/src/main/java/com/shiroha/mmdskin/NativeLibraryLoader.java
@@ -3,18 +3,18 @@ package com.shiroha.mmdskin;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import net.minecraft.client.Minecraft;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * 原生库加载器（SRP：仅负责平台检测、库提取/下载/清理/加载）
+ * 原生库加载器
+ *
+ * 桌面端：每次启动从 JAR 内提取原生库到临时目录，加载后退出时 JVM 自动清理。
+ * Android 端：沿用独立加载路径。
  */
 
 public final class NativeLibraryLoader {
@@ -65,38 +65,9 @@ public final class NativeLibraryLoader {
 
     public static boolean isAndroid() { return isAndroid; }
 
-    static final String LIBRARY_VERSION = "v1.0.4";
+    static final String LIBRARY_VERSION = "v1.0.5";
 
-    private static final String RELEASE_TAG = "v1.0.4-1.21.1";
-
-    private static final String RELEASE_BASE_URL =
-            "https://github.com/shiroha-233/MC-MMD-rust/releases/download/" + RELEASE_TAG + "/";
-
-    private static final String ENGINE_LIBRARY_DIR_NAME = "mmdskin-natives";
-
-    private static volatile String gameDirectory;
-    private static final Object DIR_LOCK = new Object();
-
-    private static String getGameDirectory() {
-        if (gameDirectory == null) {
-            synchronized (DIR_LOCK) {
-                if (gameDirectory == null) {
-                    gameDirectory = Minecraft.getInstance().gameDirectory.getAbsolutePath();
-                }
-            }
-        }
-        return gameDirectory;
-    }
-
-    private static File getEngineLibraryDir() {
-        File dir = new File(getGameDirectory(), ENGINE_LIBRARY_DIR_NAME);
-        if (!dir.exists() && !dir.mkdirs()) {
-            if (!isAndroid) {
-                logger.warn("无法创建原生库目录: " + dir.getAbsolutePath());
-            }
-        }
-        return dir;
-    }
+    private static final Path TEMP_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "mmdskin-natives");
 
     private NativeLibraryLoader() {}
 
@@ -109,23 +80,22 @@ public final class NativeLibraryLoader {
         verifyLoadedLibraryVersion(instance);
     }
 
+    // ========================================================================
+    // 桌面端：从 JAR 提取到临时目录 → System.load
+    // ========================================================================
+
     private static void loadDesktop() {
         String resourcePath;
         String fileName;
-        String downloadFileName;
 
         if (isWindows) {
             String archDir = isArm64 ? "windows-arm64" : "windows-x64";
-            logger.info("Windows Env Detected! Arch: " + archDir);
             resourcePath = "/natives/" + archDir + "/mmd_engine.dll";
             fileName = "mmd_engine.dll";
-            downloadFileName = "mmd_engine-" + archDir + ".dll";
         } else if (isMacOS) {
             String archDir = isArm64 ? "macos-arm64" : "macos-x64";
-            logger.info("macOS Env Detected! Arch: " + archDir);
             resourcePath = "/natives/" + archDir + "/libmmd_engine.dylib";
             fileName = "libmmd_engine.dylib";
-            downloadFileName = "libmmd_engine-" + archDir + ".dylib";
         } else if (isLinux) {
             String archDir;
             if (isArm64) {
@@ -137,407 +107,121 @@ public final class NativeLibraryLoader {
             } else {
                 archDir = "linux-x64";
             }
-            logger.info("Linux Env Detected! Arch: " + archDir);
             resourcePath = "/natives/" + archDir + "/libmmd_engine.so";
             fileName = "libmmd_engine.so";
-            downloadFileName = "libmmd_engine-" + archDir + ".so";
         } else {
-            String osName = System.getProperty("os.name");
-            logger.error("不支持的操作系统: " + osName);
-            throw new UnsupportedOperationException("Unsupported OS: " + osName);
+            throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
         }
 
-        File engineDir = getEngineLibraryDir();
-        logger.info("原生库目录: " + engineDir.getAbsolutePath());
-        cleanupOldLibraries(fileName, downloadFileName, engineDir);
+        logger.info("原生库 JAR 资源: {}", resourcePath);
 
-        File existingEngine = findEngineLibraryFile(engineDir, fileName, downloadFileName);
-        if (existingEngine != null) {
-            try {
-                System.load(existingEngine.getAbsolutePath());
-                return;
-            } catch (Error e) {
-                logger.error("外置库加载失败: " + e.getClass().getName() + ": " + e.getMessage(), e);
-            }
+        // 清理上次残留的临时文件
+        cleanTempDir();
+
+        // 创建临时目录
+        try {
+            Files.createDirectories(TEMP_DIR);
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError("无法创建临时目录: " + TEMP_DIR);
         }
 
-        File extracted = extractNativeLibrary(resourcePath, fileName, engineDir);
-        if (extracted != null) {
-            try {
-                System.load(extracted.getAbsolutePath());
-                return;
-            } catch (Error e) {
-                logger.error("内置库加载失败: " + e.getClass().getName() + ": " + e.getMessage(), e);
-            }
+        // 从 JAR 提取到临时目录
+        Path targetPath = TEMP_DIR.resolve(fileName);
+        try {
+            extractFromJar(resourcePath, targetPath);
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError("无法提取原生库 " + resourcePath + ": " + e.getMessage());
         }
 
-        File downloaded = downloadNativeLibrary(downloadFileName, engineDir);
-        if (downloaded != null) {
-            try {
-                System.load(downloaded.getAbsolutePath());
-                return;
-            } catch (Error e) {
-                logger.error("下载的库加载失败: " + e.getClass().getName() + ": " + e.getMessage(), e);
-            }
-        }
+        // Mark deleteOnExit so JVM cleans up
+        try {
+            targetPath.toFile().deleteOnExit();
+        } catch (Exception ignored) {}
 
-        throw new UnsatisfiedLinkError("无法加载原生库: " + getVersionedFileName(fileName)
-                + "，请检查网络连接或从 " + RELEASE_BASE_URL + " 手动下载并放入 "
-                + engineDir.getAbsolutePath());
+        // 加载
+        try {
+            System.load(targetPath.toAbsolutePath().toString());
+            logger.info("原生库加载成功: {}", targetPath);
+        } catch (UnsatisfiedLinkError e) {
+            throw new UnsatisfiedLinkError("加载原生库失败: " + e.getMessage());
+        }
     }
+
+    private static void extractFromJar(String resourcePath, Path targetPath) throws IOException {
+        try (InputStream is = NativeLibraryLoader.class.getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IOException("JAR 内资源不存在: " + resourcePath);
+            }
+            Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static void cleanTempDir() {
+        File dir = TEMP_DIR.toFile();
+        File[] files = dir.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                try {
+                    Files.deleteIfExists(f.toPath());
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
+
+    // ========================================================================
+    // Android 端：加载路径保持不变
+    // ========================================================================
 
     private static void loadAndroid() {
         String archDir = "android-a" + (isArm64 ? "rm" : "md") + "64";
-
         String soFileName = "libmmd_engine.so";
-        String downloadFileName = "libmmd_engine-" + archDir + ".so";
+        String resourcePath = "/natives/" + archDir + "/" + soFileName;
 
-        File engineDir = getEngineLibraryDir();
-        cleanupOldLibraries(soFileName, downloadFileName, engineDir);
-
-        boolean isLibcLoaded = isLibcLoaded();
-        String libcPath = null;
-        if (!isLibcLoaded) {
-            try {
-                libcPath = findLibcPath();
-            } catch (Throwable t) {
-                libcPath = null;
-            }
+        // 尝试从环境指定的目录加载 (Pojav/FCL)
+        String nativeDirEnv = System.getenv("POJAV_NATIVEDIR");
+        if (nativeDirEnv == null) {
+            nativeDirEnv = System.getenv("FCL_NATIVEDIR");
         }
-
-        if (!isLibcLoaded && libcPath != null) {
-            try {
-                System.load(libcPath);
-                isLibcLoaded = true;
-            } catch (Throwable e) {
-                libcPath = null;
-            }
-        }
-
-        File engineLibrary = findEngineLibraryFile(engineDir, soFileName, downloadFileName);
-        if (engineLibrary == null) {
-            engineLibrary = downloadNativeLibrary(downloadFileName, engineDir);
-        }
-
-        if (tryLoadAndroidEngine(engineLibrary)) {
-            return;
-        }
-
-        throw new UnsatisfiedLinkError("[Android] 无法加载原生库 libmmd_engine.so。"
-                + "请检查网络连接或从 " + RELEASE_BASE_URL + " 手动下载并放入 "
-                + engineDir.getAbsolutePath());
-    }
-
-    private static boolean isLibcLoaded() {
-        try {
-            java.lang.reflect.Field field = ClassLoader.class.getDeclaredField("loadedLibraryNames");
-            field.setAccessible(true);
-            Object value = field.get(ClassLoader.getSystemClassLoader());
-            if (value instanceof java.util.Vector) {
-                for (Object item : (java.util.Vector<?>) value) {
-                    if (item instanceof String && ((String) item).endsWith("libc++_shared.so")) {
-                        return true;
-                    }
-                }
-            }
-        } catch (Throwable ignored) {
-        }
-        return false;
-    }
-
-    private static String findLibcPath() {
-        String[] candidates = new String[] {
-                "/apex/com.android.runtime/lib64/libc++_shared.so",
-                "/apex/com.android.runtime/lib/libc++_shared.so",
-                "/system/lib64/libc++_shared.so",
-                "/system/lib/libc++_shared.so",
-                "/vendor/lib64/libc++_shared.so",
-                "/vendor/lib/libc++_shared.so"
-        };
-        for (String path : candidates) {
-            try {
-                File file = new File(path);
-                if (file.isFile()) {
-                    return file.getAbsolutePath();
-                }
-            } catch (Throwable ignored) {
-            }
-        }
-        return null;
-    }
-
-    private static File getAndroidTempNativeDir() {
-        File tempDir = new File(System.getProperty("java.io.tmpdir"), "mmdskin-natives");
-        if (!tempDir.exists()) {
-            tempDir.mkdirs();
-        }
-        return tempDir.isDirectory() ? tempDir : null;
-    }
-
-    private static boolean shouldCopyLibrary(File source, File target) {
-        if (source == null || target == null) {
-            return false;
-        }
-        if (!target.exists()) {
-            return true;
-        }
-        long sourceSize = source.length();
-        long targetSize = target.length();
-        if (sourceSize != targetSize) {
-            return true;
-        }
-        return source.lastModified() > target.lastModified();
-    }
-
-    private static File copyToTempDir(File source, File tempDir) {
-        if (source == null || tempDir == null) {
-            return null;
-        }
-        try {
-            File target = new File(tempDir, source.getName());
-            if (shouldCopyLibrary(source, target)) {
-                Files.copy(source.toPath(), target.toPath(),
-                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
-            }
-            return target;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private static boolean tryLoadAndroidEngine(File source) {
-        if (source == null) {
-            return false;
-        }
-        File tempDir = getAndroidTempNativeDir();
-        if (tempDir == null) {
-            return false;
-        }
-        File copied = copyToTempDir(source, tempDir);
-        if (copied == null) {
-            return false;
-        }
-        try {
-            System.load(copied.getAbsolutePath());
-            return true;
-        } catch (Throwable e) {
-            return false;
-        }
-    }
-
-    private static File findEngineLibraryFile(File dir, String fileName, String downloadFileName) {
-        if (dir == null) {
-            return null;
-        }
-        java.util.ArrayList<String> names = new java.util.ArrayList<>();
-        if (fileName != null && !fileName.isEmpty()) {
-            names.add(fileName);
-            names.add(getVersionedFileName(fileName));
-        }
-        if (downloadFileName != null && !downloadFileName.isEmpty()) {
-            names.add(downloadFileName);
-            names.add(getVersionedFileName(downloadFileName));
-        }
-        for (String name : names) {
-            File direct = new File(dir, name);
-            if (direct.isFile()) {
-                return direct;
-            }
-        }
-        return null;
-    }
-
-    private static boolean ensureLibcLoaded(String libcResource, String libcFileName, File targetDir) {
-        return isLibcLoaded();
-    }
-
-    private static String getVersionedFileName(String baseFileName) {
-        int dotIndex = baseFileName.lastIndexOf('.');
-        if (dotIndex > 0) {
-            return baseFileName.substring(0, dotIndex) + "_" + RELEASE_TAG + baseFileName.substring(dotIndex);
-        }
-        return baseFileName + "_" + RELEASE_TAG;
-    }
-
-    private static File extractNativeLibrary(String resourcePath, String fileName) {
-        return extractNativeLibrary(resourcePath, fileName, getEngineLibraryDir());
-    }
-
-    private static File extractNativeLibrary(String resourcePath, String fileName, File targetDir) {
-        try {
-            String versionedName = getVersionedFileName(fileName);
-            if (targetDir == null) {
-                targetDir = getEngineLibraryDir();
-            }
-            if (!targetDir.exists() && !targetDir.mkdirs()) {
-                logger.warn("无法创建目标目录: " + targetDir);
-            }
-            if (!targetDir.canWrite()) {
-                logger.warn("目标目录不可写: " + targetDir);
-                targetDir = getEngineLibraryDir();
-                if (!targetDir.exists()) {
-                    targetDir.mkdirs();
-                }
-            }
-
-            Path targetPath = Paths.get(targetDir.getAbsolutePath(), versionedName);
-            File targetFile = targetPath.toFile();
-
-            if (targetFile.exists()) {
-                return targetFile;
-            }
-
-            try (InputStream is = NativeLibraryLoader.class.getResourceAsStream(resourcePath)) {
-                if (is == null) {
-                    logger.warn("内置原生库未找到: " + resourcePath);
-                    return null;
-                }
-                Path tempPath = Paths.get(targetDir.getAbsolutePath(), versionedName + ".tmp");
-                Files.copy(is, tempPath, StandardCopyOption.REPLACE_EXISTING);
-                Files.move(tempPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
-            }
-
-            return targetFile;
-        } catch (Exception e) {
-            logger.error("提取原生库失败: " + resourcePath + " - " + e.getMessage());
-            return null;
-        }
-    }
-
-    private static File downloadNativeLibrary(String downloadFileName) {
-        return downloadNativeLibrary(downloadFileName, getEngineLibraryDir());
-    }
-
-    private static File downloadNativeLibrary(String downloadFileName, File targetDir) {
-        try {
-            String versionedName = getVersionedFileName(downloadFileName);
-            if (targetDir == null) {
-                targetDir = getEngineLibraryDir();
-            }
-            if (!targetDir.exists() && !targetDir.mkdirs()) {
-                if (!isAndroid) {
-                    logger.warn("无法创建目标目录: " + targetDir);
-                }
-            }
-            if (!targetDir.canWrite()) {
-                if (!isAndroid) {
-                    logger.warn("目标目录不可写: " + targetDir);
-                }
-                targetDir = getEngineLibraryDir();
-                if (!targetDir.exists()) {
-                    targetDir.mkdirs();
-                }
-            }
-
-            Path targetPath = Paths.get(targetDir.getAbsolutePath(), versionedName);
-
-            if (targetPath.toFile().exists()) {
-                return targetPath.toFile();
-            }
-
-            String urlStr = RELEASE_BASE_URL + versionedName;
-
-            HttpURLConnection conn = null;
-            for (int i = 0; i < 5; i++) {
-                conn = (HttpURLConnection) new URL(urlStr).openConnection();
-                conn.setInstanceFollowRedirects(false);
-                conn.setConnectTimeout(15000);
-                conn.setReadTimeout(60000);
-                conn.setRequestProperty("User-Agent", "MMDSkin-Mod/" + LIBRARY_VERSION);
-
-                int code = conn.getResponseCode();
-                if (code == HttpURLConnection.HTTP_MOVED_TEMP
-                        || code == HttpURLConnection.HTTP_MOVED_PERM
-                        || code == 307 || code == 308) {
-                    urlStr = conn.getHeaderField("Location");
-                    conn.disconnect();
-                    continue;
-                }
-                break;
-            }
-
-            if (conn == null || conn.getResponseCode() != 200) {
-                if (!isAndroid) {
-                    logger.warn("下载失败，HTTP 状态码: " + (conn != null ? conn.getResponseCode() : "无连接"));
-                }
-                if (conn != null) conn.disconnect();
-                return null;
-            }
-
-            long contentLength = conn.getContentLengthLong();
-
-            Path tempPath = Paths.get(targetDir.getAbsolutePath(), versionedName + ".download");
-            try (InputStream is = conn.getInputStream()) {
-                Files.copy(is, tempPath, StandardCopyOption.REPLACE_EXISTING);
-            }
-
-            Files.move(tempPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
-            conn.disconnect();
-            return targetPath.toFile();
-        } catch (Exception e) {
-            if (!isAndroid) {
-                logger.error("下载原生库失败: " + downloadFileName + " - " + e.getMessage());
-            }
-            try {
-                Files.deleteIfExists(Paths.get(targetDir.getAbsolutePath(), getVersionedFileName(downloadFileName) + ".download"));
-            } catch (Exception ignored) {}
-            return null;
-        }
-    }
-
-    private static void cleanupOldLibraries(String baseFileName, String downloadBaseFileName) {
-        cleanupOldLibraries(baseFileName, downloadBaseFileName, getEngineLibraryDir());
-    }
-
-    private static void cleanupOldLibraries(String baseFileName, String downloadBaseFileName, File targetDir) {
-        try {
-            File gameDir = targetDir != null ? targetDir : getEngineLibraryDir();
-            int dotIndex = baseFileName.lastIndexOf('.');
-            if (dotIndex <= 0) return;
-
-            String baseName = baseFileName.substring(0, dotIndex);
-            String ext = baseFileName.substring(dotIndex);
-            String currentVersionedLocal = getVersionedFileName(baseFileName);
-            String currentVersionedDownload = getVersionedFileName(downloadBaseFileName);
-
-            File[] files = gameDir.listFiles();
-            if (files == null) return;
-
-            for (File f : files) {
-                String name = f.getName();
-                if (name.equals(currentVersionedLocal) || name.equals(currentVersionedDownload)) continue;
-
-                boolean shouldDelete = false;
-
-                if (name.startsWith(baseName) && name.contains("_v") && (name.endsWith(ext)
-                        || name.endsWith(ext + ".download") || name.endsWith(ext + ".tmp"))) {
-                    shouldDelete = true;
-                }
-                if (name.equals(baseFileName)
-                        || name.equals(baseFileName + ".version")
-                        || name.equals(baseFileName + ".old")
-                        || name.equals(baseFileName + ".new")
-                        || name.equals(baseFileName + ".download")) {
-                    shouldDelete = true;
-                }
-
-                if (shouldDelete) {
+        if (nativeDirEnv != null) {
+            File envDir = new File(nativeDirEnv);
+            if (envDir.isDirectory()) {
+                File envLib = new File(envDir, soFileName);
+                if (envLib.isFile()) {
                     try {
-                        if (f.delete()) {
-                        }
-                    } catch (Exception e) {
-                        if (!isAndroid) {
-                            logger.debug("清理旧文件失败（可能仍被锁定）: " + name);
-                        }
+                        System.load(envLib.getAbsolutePath());
+                        return;
+                    } catch (Error ignored) {
                     }
                 }
             }
-        } catch (Exception e) {
-            if (!isAndroid) {
-                logger.debug("清理旧版本库文件时出错: " + e.getMessage());
-            }
+        }
+
+        // 从 JAR 提取到应用缓存目录
+        cleanTempDir();
+        try {
+            Files.createDirectories(TEMP_DIR);
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError("[Android] 无法创建原生库目录: " + TEMP_DIR);
+        }
+
+        Path targetPath = TEMP_DIR.resolve(soFileName);
+        try {
+            extractFromJar(resourcePath, targetPath);
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError("[Android] 无法提取原生库: " + resourcePath);
+        }
+
+        try {
+            System.load(targetPath.toAbsolutePath().toString());
+        } catch (Error e) {
+            throw new UnsatisfiedLinkError("[Android] 加载原生库失败: " + e.getMessage());
         }
     }
+
+    // ========================================================================
+    // 版本校验
+    // ========================================================================
 
     private static void verifyLoadedLibraryVersion(NativeFunc instance) {
         try {
@@ -546,12 +230,12 @@ public final class NativeLibraryLoader {
                 return;
             }
             if (!isAndroid) {
-                logger.warn("原生库版本不匹配！Java 侧期望: " + LIBRARY_VERSION + ", Rust 侧实际: " + rustVersion);
-                logger.warn("这通常发生在开发环境或手动放置库文件时，请确保 Rust 引擎和 Java 模组版本一致。");
+                logger.warn("原生库版本不匹配！Java 侧期望: {}, Rust 侧实际: {}", LIBRARY_VERSION, rustVersion);
+                logger.warn("请确保 Rust 引擎和 Java 模组版本一致。");
             }
         } catch (Exception | Error e) {
             if (!isAndroid) {
-                logger.warn("运行时版本校验失败（GetVersion 调用异常）: " + e.getMessage());
+                logger.warn("运行时版本校验失败（GetVersion 调用异常）: {}", e.getMessage());
             }
         }
     }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -131,13 +131,16 @@ shadowJar {
     configurations = [project.configurations.shadowCommon, project.configurations.shadowBundle]
     archiveClassifier.set("dev-shadow")
     relocate "javazoom", "com.shiroha.mmdskin.shadow.javazoom"
-    
+
+    // 包含 common 模块的资源（原生库、默认动画等）
+    from(project(":common").sourceSets.main.resources)
+
     // 排除不需要的文件
     exclude 'META-INF/versions/**'
-    
+
     // 强制更新 META-INF/services 里的类名
     mergeServiceFiles()
-    
+
     // 排除 module-info.class 避免 JPMS 冲突
     exclude 'module-info.class'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2G -Djava.net.preferIPv4Stack=true -Dhttps.protocols=TLSv1.2,TLSv1.3 
+org.gradle.jvmargs=-Xmx2G -Djava.net.preferIPv4Stack=true -Dhttps.protocols=TLSv1.2,TLSv1.3 -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 # Fabric Properties

--- a/rust_engine/src/jni_bridge/mod.rs
+++ b/rust_engine/src/jni_bridge/mod.rs
@@ -33,6 +33,10 @@ pub static ANIMATIONS: Lazy<RwLock<HashMap<i64, Arc<VmdAnimation>>>> =
 pub static TEXTURES: Lazy<RwLock<HashMap<i64, Arc<Texture>>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
+/// 纹理路径 → 句柄索引（避免重复加载同一文件）
+pub static TEXTURE_PATH_INDEX: Lazy<RwLock<HashMap<String, i64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
 /// 生成唯一句柄 ID
 fn next_handle_id() -> i64 {
     use std::sync::atomic::{AtomicI64, Ordering};

--- a/rust_engine/src/jni_bridge/native_func.rs
+++ b/rust_engine/src/jni_bridge/native_func.rs
@@ -13,6 +13,7 @@ use crate::texture::load_texture;
 
 use super::{
     register_animation, register_model, register_texture, ANIMATIONS, FBX_CACHE, MODELS, TEXTURES,
+    TEXTURE_PATH_INDEX,
 };
 
 const VERSION: &str = "v1.0.5";
@@ -1562,7 +1563,7 @@ pub extern "system" fn Java_com_shiroha_mmdskin_NativeFunc_SetLayerLoop(
 // 纹理相关函数
 // ============================================================================
 
-/// 加载纹理
+/// 加载纹理（带路径去重缓存）
 #[no_mangle]
 pub extern "system" fn Java_com_shiroha_mmdskin_NativeFunc_LoadTexture(
     mut env: JNIEnv,
@@ -1574,8 +1575,28 @@ pub extern "system" fn Java_com_shiroha_mmdskin_NativeFunc_LoadTexture(
         Err(_) => return 0,
     };
 
+    // 检查路径缓存：如果已加载过同一文件，直接返回已有句柄
+    {
+        let path_index = TEXTURE_PATH_INDEX.read().unwrap();
+        if let Some(&existing_id) = path_index.get(&filename_str) {
+            // 确认句柄仍然有效
+            let textures = TEXTURES.read().unwrap();
+            if textures.contains_key(&existing_id) {
+                return existing_id;
+            }
+        }
+    }
+
     match load_texture(&filename_str) {
-        Ok(texture) => register_texture(texture),
+        Ok(texture) => {
+            let id = register_texture(texture);
+            // 登记路径到句柄的映射
+            if id != 0 {
+                let mut path_index = TEXTURE_PATH_INDEX.write().unwrap();
+                path_index.insert(filename_str, id);
+            }
+            id
+        }
         Err(e) => {
             log::error!("Failed to load texture: {}", e);
             0
@@ -3326,8 +3347,6 @@ pub extern "system" fn Java_com_shiroha_mmdskin_NativeFunc_SetVRIKParams(
     }
 }
 
-/// 设置舞台模式腿部 IK 是否启用。
-#[no_mangle]
 /// 设置 VR 手部渲染模式（0=全身, 1=仅左手, 2=仅右手）
 #[no_mangle]
 pub extern "system" fn Java_com_shiroha_mmdskin_NativeFunc_SetVRHandMode(

--- a/rust_engine/src/model/runtime.rs
+++ b/rust_engine/src/model/runtime.rs
@@ -2364,11 +2364,10 @@ impl MmdModel {
     /// 流程：sync_bodies → stepSimulation → sync_bones
     /// 所有中间数据复用预分配缓冲区，零堆分配。
     pub fn update_physics(&mut self, delta_time: f32) {
+        let config = crate::physics::config::get_config();
+
         // 全局开关 + per-model 开关双重检查
-        if !crate::physics::config::get_config().enabled
-            || !self.physics_enabled
-            || self.physics.is_none()
-        {
+        if !config.enabled || !self.physics_enabled || self.physics.is_none() {
             return;
         }
 
@@ -2390,10 +2389,11 @@ impl MmdModel {
             &self.physics_bone_transforms_buf,
             delta_time,
             model_transform,
+            &config,
         );
 
-        // 2. Bullet3 步进
-        physics.step_simulation(delta_time);
+        // 2. Bullet3 步进（传入 config 避免内部重复 get_config）
+        physics.step_simulation(delta_time, &config);
 
         // 3. 同步物理结果回骨骼（复用内部缓冲区）
         let dynamic_bone_transforms =

--- a/rust_engine/src/physics/mmd_physics.rs
+++ b/rust_engine/src/physics/mmd_physics.rs
@@ -11,7 +11,7 @@ use mmd::pmx::joint::Joint as PmxJoint;
 use mmd::pmx::rigid_body::RigidBody as PmxRigidBody;
 
 use super::bullet_ffi::{self, BulletWorld};
-use super::config::get_config;
+use super::config::{get_config, PhysicsConfig};
 use super::mmd_joint::MmdJointData;
 use super::mmd_rigid_body::{MmdRigidBodyData, PhysicsMode};
 
@@ -173,21 +173,14 @@ impl MMDPhysics {
 
         self.world.set_kinematic_filter(config.kinematic_filter);
 
-        let kinematic_count = self
-            .rigid_bodies
-            .iter()
-            .filter(|rb| rb.physics_mode == PhysicsMode::FollowBone)
-            .count();
-        let dynamic_count = self
-            .rigid_bodies
-            .iter()
-            .filter(|rb| rb.physics_mode == PhysicsMode::Physics)
-            .count();
-        let dynamic_bone_count = self
-            .rigid_bodies
-            .iter()
-            .filter(|rb| rb.physics_mode == PhysicsMode::PhysicsWithBone)
-            .count();
+        let (kinematic_count, dynamic_count, dynamic_bone_count) =
+            self.rigid_bodies
+                .iter()
+                .fold((0, 0, 0), |(k, d, db), rb| match rb.physics_mode {
+                    PhysicsMode::FollowBone => (k + 1, d, db),
+                    PhysicsMode::Physics => (k, d + 1, db),
+                    PhysicsMode::PhysicsWithBone => (k, d, db + 1),
+                });
 
         log::info!(
             "Bullet3 物理构建完成: {} 刚体 ({}跟骨 + {}物理 + {}物理跟骨), {} 关节",
@@ -233,8 +226,8 @@ impl MMDPhysics {
         bone_transforms: &[Mat4],
         delta_time: f32,
         model_transform: Mat4,
+        config: &PhysicsConfig,
     ) {
-        let config = get_config();
         let dt = delta_time.max(0.001);
         let curr_pos = model_transform.w_axis.truncate();
 
@@ -301,13 +294,12 @@ impl MMDPhysics {
     ///
     /// Bullet3 没有内置全局速度限制，需在每步后手动截断超速刚体，
     /// 防止卡顿帧或极端力导致的物理爆炸。
-    pub fn step_simulation(&self, delta_time: f32) {
+    pub fn step_simulation(&self, delta_time: f32, config: &PhysicsConfig) {
         let fixed_dt = 1.0 / self.fps;
         self.world
             .step(delta_time, self.max_substep_count, fixed_dt);
 
         // 速度钳制
-        let config = get_config();
         let max_lin = config.max_linear_velocity;
         let max_ang = config.max_angular_velocity;
         let max_lin_sq = max_lin * max_lin;

--- a/rust_engine/src/skeleton/bone_set.rs
+++ b/rust_engine/src/skeleton/bone_set.rs
@@ -616,7 +616,7 @@ impl BoneSet {
 
     /// 批量更新物理骨骼后，更新非物理骨骼
     pub fn update_non_physics_children(&mut self, physics_bone_indices: &HashSet<usize>) {
-        for &idx in &self.sorted_indices.clone() {
+        for &idx in &self.sorted_indices {
             if physics_bone_indices.contains(&idx) {
                 continue;
             }

--- a/rust_engine/src/texture/loader.rs
+++ b/rust_engine/src/texture/loader.rs
@@ -18,17 +18,32 @@ fn texture_from_image(img: DynamicImage) -> Texture {
     let (width, height) = img.dimensions();
     let has_alpha = has_alpha_channel(&img);
 
-    // 与C++一致：垂直翻转图像，然后根据是否有alpha通道选择格式
+    let w = width as usize;
+    let h = height as usize;
+
     let data = if has_alpha {
-        // RGBA格式（4字节/像素）
-        let rgba = img.to_rgba8();
-        let flipped = image::imageops::flip_vertical(&rgba);
-        flipped.into_raw()
+        let raw = img.to_rgba8().into_raw();
+        let row_bytes = w * 4;
+        // 单次分配 + 垂直翻转（避免 to_rgba8 + flip_vertical 双分配）
+        let mut flipped = vec![0u8; raw.len()];
+        for src_row in 0..h {
+            let dst_row = h - 1 - src_row;
+            let src = src_row * row_bytes;
+            let dst = dst_row * row_bytes;
+            flipped[dst..dst + row_bytes].copy_from_slice(&raw[src..src + row_bytes]);
+        }
+        flipped
     } else {
-        // RGB格式（3字节/像素）- 与C++的STBI_rgb一致
-        let rgb = img.to_rgb8();
-        let flipped = image::imageops::flip_vertical(&rgb);
-        flipped.into_raw()
+        let raw = img.to_rgb8().into_raw();
+        let row_bytes = w * 3;
+        let mut flipped = vec![0u8; raw.len()];
+        for src_row in 0..h {
+            let dst_row = h - 1 - src_row;
+            let src = src_row * row_bytes;
+            let dst = dst_row * row_bytes;
+            flipped[dst..dst + row_bytes].copy_from_slice(&raw[src..src + row_bytes]);
+        }
+        flipped
     };
 
     Texture::new(width, height, data, has_alpha)


### PR DESCRIPTION
## 物理系统优化 (4项)
- bone_set.rs: 移除 update_non_physics_children() 中 sorted_indices.clone() 每帧堆分配
- mmd_physics.rs: sync_bodies_with_model_velocity / step_simulation 改为接受 &PhysicsConfig 引用，消除内部 get_config().clone() 重复调用
- mmd_physics.rs: build_physics() 中三次 .filter().count() 遍历合并为单次 .fold()
- runtime.rs: update_physics() 入口缓存 get_config() 一次，传递给下游方法；get_config() 从每帧3次调用降为1次

## 纹理系统优化 (2项)
- texture/loader.rs: texture_from_image() 中 to_rgba8/to_rgb8 + flip_vertical 两次分配合并为单次 vec 分配 + 逐行翻转，内存峰值减半
- jni_bridge: 新增 TEXTURE_PATH_INDEX 路径去重缓存，同一贴图文件只解码一次，复用 Arc<Texture> 句柄

## 构建系统: Rust DLL 自动打包进 JAR
- build.gradle: 新增 buildRustEngine / copyRustNatives / findCargo 任务，Gradle build 自动编译 Rust 并复制产物到 common/resources/natives/
- common:processResources 与 sourcesJar 均依赖 copyRustNatives
- fabric/build.gradle: shadowJar 包含 common.sourceSets.main.resources
- gradle.properties: 添加 -Dfile.encoding=UTF-8 修复 Windows 中文乱码

## NativeLibraryLoader 重写
- 移除三层降级加载(内置/外置/下载)，改为每次启动从 JAR 提取到 java.io.tmpdir 后 System.load
- deleteOnExit 标记，JVM 退出自动清理
- LIBRARY_VERSION 同步为 v1.0.5

## 代码清理
- native_func.rs: 删除重复的 #[no_mangle] 属性和孤立文档注释