### PR TITLE
fix: 修复 SkinningComputeShader / PhysicsComputeShader GL Buffer 资源泄漏

### DIFF
--- a/common/src/main/java/com/shiroha/mmdskin/render/shader/PhysicsComputeShader.java
+++ b/common/src/main/java/com/shiroha/mmdskin/render/shader/PhysicsComputeShader.java
@@ -118,19 +118,24 @@ public class PhysicsComputeShader {
 
     /** 创建物理状态 SSBO（ping-pong 双缓冲） */
     public static int[] createStateBuffers(int bindingCount) {
-        // StateData: vec4 position + vec4 velocity + vec4 prevPosition + vec4 pad + mat4 rotation = 128 bytes
         long bufferSize = (long) bindingCount * 128;
         int[] buffers = new int[2];
-        for (int i = 0; i < 2; i++) {
-            buffers[i] = GL46C.glGenBuffers();
-            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, buffers[i]);
-            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
-            // 零初始化
-            ByteBuffer zeros = ByteBuffer.allocateDirect((int) bufferSize);
-            GL46C.glBufferSubData(GL46C.GL_COPY_WRITE_BUFFER, 0, zeros);
+        try {
+            for (int i = 0; i < 2; i++) {
+                buffers[i] = GL46C.glGenBuffers();
+                GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, buffers[i]);
+                GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
+                ByteBuffer zeros = ByteBuffer.allocateDirect((int) bufferSize);
+                GL46C.glBufferSubData(GL46C.GL_COPY_WRITE_BUFFER, 0, zeros);
+            }
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return buffers;
+        } catch (Exception e) {
+            for (int i = 0; i < 2; i++) {
+                if (buffers[i] != 0) GL46C.glDeleteBuffers(buffers[i]);
+            }
+            throw e;
         }
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return buffers;
     }
 
     /** 创建 Bindings SSBO */

--- a/common/src/main/java/com/shiroha/mmdskin/render/shader/SkinningComputeShader.java
+++ b/common/src/main/java/com/shiroha/mmdskin/render/shader/SkinningComputeShader.java
@@ -101,17 +101,24 @@ public class SkinningComputeShader {
 
     public static int[] createOutputBuffers(int vertexCount) {
         long bufferSize = (long) vertexCount * 3 * 4;
+        int posBuffer = 0;
+        int norBuffer = 0;
+        try {
+            posBuffer = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, posBuffer);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
 
-        int posBuffer = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, posBuffer);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
+            norBuffer = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, norBuffer);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
 
-        int norBuffer = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, norBuffer);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
-
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{posBuffer, norBuffer};
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{posBuffer, norBuffer};
+        } catch (Exception e) {
+            if (posBuffer != 0) GL46C.glDeleteBuffers(posBuffer);
+            if (norBuffer != 0) GL46C.glDeleteBuffers(norBuffer);
+            throw e;
+        }
     }
 
     public void dispatch(DispatchParams p) {
@@ -190,21 +197,37 @@ public class SkinningComputeShader {
     }
 
     public static int[] createMorphBuffers(int morphCount) {
-        int offsetsSSBO = GL46C.glGenBuffers();
-        int weightsSSBO = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) morphCount * 4, GL46C.GL_DYNAMIC_DRAW);
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{offsetsSSBO, weightsSSBO};
+        int offsetsSSBO = 0;
+        int weightsSSBO = 0;
+        try {
+            offsetsSSBO = GL46C.glGenBuffers();
+            weightsSSBO = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) morphCount * 4, GL46C.GL_DYNAMIC_DRAW);
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{offsetsSSBO, weightsSSBO};
+        } catch (Exception e) {
+            if (offsetsSSBO != 0) GL46C.glDeleteBuffers(offsetsSSBO);
+            if (weightsSSBO != 0) GL46C.glDeleteBuffers(weightsSSBO);
+            throw e;
+        }
     }
 
     public static int[] createUvMorphBuffers(int uvMorphCount) {
-        int offsetsSSBO = GL46C.glGenBuffers();
-        int weightsSSBO = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) uvMorphCount * 4, GL46C.GL_DYNAMIC_DRAW);
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{offsetsSSBO, weightsSSBO};
+        int offsetsSSBO = 0;
+        int weightsSSBO = 0;
+        try {
+            offsetsSSBO = GL46C.glGenBuffers();
+            weightsSSBO = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) uvMorphCount * 4, GL46C.GL_DYNAMIC_DRAW);
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{offsetsSSBO, weightsSSBO};
+        } catch (Exception e) {
+            if (offsetsSSBO != 0) GL46C.glDeleteBuffers(offsetsSSBO);
+            if (weightsSSBO != 0) GL46C.glDeleteBuffers(weightsSSBO);
+            throw e;
+        }
     }
 
     public static int createSkinnedUvBuffer(int vertexCount) {

--- a/common/src/main/java/com/shiroha/mmdskin/renderer/pipeline/shader/SkinningComputeShader.java
+++ b/common/src/main/java/com/shiroha/mmdskin/renderer/pipeline/shader/SkinningComputeShader.java
@@ -101,17 +101,24 @@ public class SkinningComputeShader {
 
     public static int[] createOutputBuffers(int vertexCount) {
         long bufferSize = (long) vertexCount * 3 * 4;
+        int posBuffer = 0;
+        int norBuffer = 0;
+        try {
+            posBuffer = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, posBuffer);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
 
-        int posBuffer = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, posBuffer);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
+            norBuffer = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, norBuffer);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
 
-        int norBuffer = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, norBuffer);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, bufferSize, GL46C.GL_DYNAMIC_COPY);
-
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{posBuffer, norBuffer};
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{posBuffer, norBuffer};
+        } catch (Exception e) {
+            if (posBuffer != 0) GL46C.glDeleteBuffers(posBuffer);
+            if (norBuffer != 0) GL46C.glDeleteBuffers(norBuffer);
+            throw e;
+        }
     }
 
     public void dispatch(DispatchParams p) {
@@ -190,21 +197,37 @@ public class SkinningComputeShader {
     }
 
     public static int[] createMorphBuffers(int morphCount) {
-        int offsetsSSBO = GL46C.glGenBuffers();
-        int weightsSSBO = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) morphCount * 4, GL46C.GL_DYNAMIC_DRAW);
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{offsetsSSBO, weightsSSBO};
+        int offsetsSSBO = 0;
+        int weightsSSBO = 0;
+        try {
+            offsetsSSBO = GL46C.glGenBuffers();
+            weightsSSBO = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) morphCount * 4, GL46C.GL_DYNAMIC_DRAW);
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{offsetsSSBO, weightsSSBO};
+        } catch (Exception e) {
+            if (offsetsSSBO != 0) GL46C.glDeleteBuffers(offsetsSSBO);
+            if (weightsSSBO != 0) GL46C.glDeleteBuffers(weightsSSBO);
+            throw e;
+        }
     }
 
     public static int[] createUvMorphBuffers(int uvMorphCount) {
-        int offsetsSSBO = GL46C.glGenBuffers();
-        int weightsSSBO = GL46C.glGenBuffers();
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
-        GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) uvMorphCount * 4, GL46C.GL_DYNAMIC_DRAW);
-        GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
-        return new int[]{offsetsSSBO, weightsSSBO};
+        int offsetsSSBO = 0;
+        int weightsSSBO = 0;
+        try {
+            offsetsSSBO = GL46C.glGenBuffers();
+            weightsSSBO = GL46C.glGenBuffers();
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, weightsSSBO);
+            GL46C.glBufferData(GL46C.GL_COPY_WRITE_BUFFER, (long) uvMorphCount * 4, GL46C.GL_DYNAMIC_DRAW);
+            GL46C.glBindBuffer(GL46C.GL_COPY_WRITE_BUFFER, 0);
+            return new int[]{offsetsSSBO, weightsSSBO};
+        } catch (Exception e) {
+            if (offsetsSSBO != 0) GL46C.glDeleteBuffers(offsetsSSBO);
+            if (weightsSSBO != 0) GL46C.glDeleteBuffers(weightsSSBO);
+            throw e;
+        }
     }
 
     public static int createSkinnedUvBuffer(int vertexCount) {


### PR DESCRIPTION
createOutputBuffers / createMorphBuffers / createUvMorphBuffers / createStateBuffers 中如果第二个 glGenBuffers/glBufferData 抛异常，首个已创建的 GL Buffer 不会被释放， 导致 GPU 显存泄漏。使用 try-catch 包裹并在异常时 glDeleteBuffers 清理已分配资源。