### PR TITLE
feat(compat): yield player render to Sparkle's Morpher

### DIFF
--- a/common/src/main/java/com/shiroha/mmdskin/compat/SparkleMorpherCompat.java
+++ b/common/src/main/java/com/shiroha/mmdskin/compat/SparkleMorpherCompat.java
@@ -1,0 +1,166 @@
+package com.shiroha.mmdskin.compat;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Method;
+
+/**
+ * Sparkle's Morpher 兼容辅助类。
+ *
+ * <p>Sparkle's Morpher 是 OpenYSM 衍生的玩家模型加载器（mod id: {@code sparkle_morpher}，
+ * 包名 {@code com.micaftic.morpher}）。它与原版 YSM 共享同一渲染目标（玩家），但走独立
+ * 的网络通道与能力体系，因此 MC-M-MD 在 SparkleMorpher 模型激活时必须让出
+ * {@code PlayerRenderer.render} 的渲染权，避免二者在同一帧互相 {@code ci.cancel()}。</p>
+ *
+ * <p>本类全部通过反射访问 SparkleMorpher 的公开 API：{@code YesSteveModel.isAvailable()}、
+ * {@code PlayerCapability.get(Entity)} -> {@code Optional} -> {@code cap.isModelActive()}，
+ * 以及 {@code GeneralConfig} 上的 DISABLE_SELF_MODEL / DISABLE_OTHER_MODEL / DISABLE_SELF_HANDS
+ * 开关。运行时 SparkleMorpher 缺失则静默返回 {@code false}，与 {@code YsmCompat} 对官方 YSM
+ * 的处理保持一致。</p>
+ */
+public final class SparkleMorpherCompat {
+    private static final Logger logger = LogManager.getLogger();
+
+    private static volatile int initState = 0; // 0=未初始化, 1=存在, -1=缺失
+    private static volatile boolean present = false;
+
+    private static volatile Method isAvailableMethod;     // YesSteveModel.isAvailable() -> boolean
+    private static volatile Method capabilityGetMethod;    // PlayerCapability.get(Entity) -> Optional
+    private static volatile Method optionalOrElseMethod;  // Optional.orElse(Object) -> Object
+    private static volatile Method isModelActiveMethod;    // cap.isModelActive() -> boolean
+
+    private static volatile Object disableSelfModelValue;
+    private static volatile Object disableOtherModelValue;
+    private static volatile Object disableSelfHandsValue;
+    private static volatile Method booleanValueGetMethod;
+
+    private SparkleMorpherCompat() {
+    }
+
+    private static void ensureInit() {
+        if (initState != 0) {
+            return;
+        }
+        synchronized (SparkleMorpherCompat.class) {
+            if (initState != 0) {
+                return;
+            }
+            try {
+                Class<?> mainClass = Class.forName("com.micaftic.morpher.YesSteveModel");
+                isAvailableMethod = mainClass.getMethod("isAvailable");
+
+                Class<?> capClass = Class.forName("com.micaftic.morpher.capability.PlayerCapability");
+                // 优先 get(Entity)，回退 get(Player)；二者均为 @ExpectPlatform 静态方法。
+                try {
+                    capabilityGetMethod = capClass.getMethod("get", Entity.class);
+                } catch (NoSuchMethodException e) {
+                    capabilityGetMethod = capClass.getMethod("get", Player.class);
+                }
+
+                Class<?> optionalClass = Class.forName("java.util.Optional");
+                optionalOrElseMethod = optionalClass.getMethod("orElse", Object.class);
+
+                // isModelActive 定义在祖先类 LivingAnimatable，getMethod 会沿继承链查找。
+                isModelActiveMethod = capClass.getMethod("isModelActive");
+
+                Class<?> configClass = Class.forName("com.micaftic.morpher.config.GeneralConfig");
+                disableSelfModelValue = configClass.getField("DISABLE_SELF_MODEL").get(null);
+                disableOtherModelValue = configClass.getField("DISABLE_OTHER_MODEL").get(null);
+                disableSelfHandsValue = configClass.getField("DISABLE_SELF_HANDS").get(null);
+
+                if (disableSelfModelValue != null) {
+                    booleanValueGetMethod = disableSelfModelValue.getClass().getMethod("get");
+                }
+
+                present = true;
+                initState = 1;
+            } catch (Throwable t) {
+                logger.debug("SparkleMorpher compat not initialized: {}", t.getMessage());
+                present = false;
+                initState = -1;
+            }
+        }
+    }
+
+    /** SparkleMorpher 是否已安装且原生加速可用。 */
+    public static boolean isSparkleAvailable() {
+        ensureInit();
+        if (!present || isAvailableMethod == null) {
+            return false;
+        }
+        try {
+            return (boolean) isAvailableMethod.invoke(null);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** 该实体上是否挂载了激活的 SparkleMorpher 模型（不考虑自/他显示开关）。 */
+    public static boolean isSparkleModelActive(LivingEntity entity) {
+        ensureInit();
+        if (!present || !isSparkleAvailable()
+                || capabilityGetMethod == null || isModelActiveMethod == null || optionalOrElseMethod == null) {
+            return false;
+        }
+        try {
+            Object optional = capabilityGetMethod.invoke(null, entity);
+            if (optional == null) {
+                return false;
+            }
+            Object cap = optionalOrElseMethod.invoke(optional, new Object[]{ null });
+            if (cap == null) {
+                return false;
+            }
+            return (boolean) isModelActiveMethod.invoke(cap);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /**
+     * 该实体上 SparkleMorpher 模型是否应当接管渲染（考虑自/他显示开关），
+     * 与官方 YSM 的 {@code isYsmActive} 语义对齐。MC-M-MD 据此让出渲染权。
+     */
+    public static boolean isSparkleActive(LivingEntity entity) {
+        if (!isSparkleModelActive(entity)) {
+            return false;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        boolean isLocalPlayer = mc.player != null && mc.player.getUUID().equals(entity.getUUID());
+        return isLocalPlayer ? !isDisableSelfModel() : !isDisableOtherModel();
+    }
+
+    /** SparkleMorpher 是否开启了“阻止自身模型渲染”。 */
+    public static boolean isDisableSelfModel() {
+        ensureInit();
+        return getBooleanValue(disableSelfModelValue);
+    }
+
+    /** SparkleMorpher 是否开启了“阻止其他玩家模型渲染”。 */
+    public static boolean isDisableOtherModel() {
+        ensureInit();
+        return getBooleanValue(disableOtherModelValue);
+    }
+
+    /** SparkleMorpher 是否开启了“阻止自身手臂渲染”。 */
+    public static boolean isDisableSelfHands() {
+        ensureInit();
+        return getBooleanValue(disableSelfHandsValue);
+    }
+
+    private static boolean getBooleanValue(Object valueObj) {
+        if (present && valueObj != null && booleanValueGetMethod != null) {
+            try {
+                return (boolean) booleanValueGetMethod.invoke(valueObj);
+            } catch (Throwable t) {
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/fabric/src/main/java/com/shiroha/mmdskin/fabric/YsmCompat.java
+++ b/fabric/src/main/java/com/shiroha/mmdskin/fabric/YsmCompat.java
@@ -1,5 +1,6 @@
 package com.shiroha.mmdskin.fabric;
 
+import com.shiroha.mmdskin.compat.SparkleMorpherCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.LivingEntity;
 import net.fabricmc.loader.api.FabricLoader;
@@ -22,20 +23,28 @@ public class YsmCompat {
     private static Method booleanValueGetMethod = null;
 
     public static boolean isYsmActive(LivingEntity entity) {
-        if (!isYsmModelActive(entity)) {
-            return false;
-        }
-
         Minecraft mc = Minecraft.getInstance();
         boolean isLocalPlayer = mc.player != null && mc.player.getUUID().equals(entity.getUUID());
-        if (isLocalPlayer) {
-            return !isDisableSelfModel();
-        } else {
-            return !isDisableOtherModel();
+
+        // 官方 YSM：模型激活且未按自/他开关禁用。
+        if (isOfficialYsmModelActive(entity)) {
+            boolean disabled = isLocalPlayer
+                    ? getBooleanValue(disableSelfModelValue)
+                    : getBooleanValue(disableOtherModelValue);
+            if (!disabled) {
+                return true;
+            }
         }
+
+        // Sparkle's Morpher：自带自/他开关语义，激活时让出渲染权。
+        return SparkleMorpherCompat.isSparkleActive(entity);
     }
 
     public static boolean isYsmModelActive(LivingEntity entity) {
+        return isOfficialYsmModelActive(entity) || SparkleMorpherCompat.isSparkleModelActive(entity);
+    }
+
+    private static boolean isOfficialYsmModelActive(LivingEntity entity) {
         if (!ysmChecked) {
             ysmPresent = FabricLoader.getInstance().isModLoaded("yes_steve_model");
             if (ysmPresent) {
@@ -72,15 +81,15 @@ public class YsmCompat {
     }
 
     public static boolean isDisableSelfModel() {
-        return getBooleanValue(disableSelfModelValue);
+        return getBooleanValue(disableSelfModelValue) || SparkleMorpherCompat.isDisableSelfModel();
     }
 
     public static boolean isDisableOtherModel() {
-        return getBooleanValue(disableOtherModelValue);
+        return getBooleanValue(disableOtherModelValue) || SparkleMorpherCompat.isDisableOtherModel();
     }
 
     public static boolean isDisableSelfHands() {
-        return getBooleanValue(disableSelfHandsValue);
+        return getBooleanValue(disableSelfHandsValue) || SparkleMorpherCompat.isDisableSelfHands();
     }
 
     private static boolean getBooleanValue(Object valueObj) {

--- a/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/YsmCompat.java
+++ b/neoforge/src/main/java/com/shiroha/mmdskin/neoforge/YsmCompat.java
@@ -1,5 +1,6 @@
 package com.shiroha.mmdskin.neoforge;
 
+import com.shiroha.mmdskin.compat.SparkleMorpherCompat;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import org.apache.logging.log4j.LogManager;
@@ -28,23 +29,28 @@ public class YsmCompat {
     * 判断实体是否应当显示 YSM 模型（而非原版/MMD）
     */
    public static boolean isYsmActive(LivingEntity entity) {
-      if (!isYsmModelActive(entity)) {
-         return false;
-      }
-      
       Minecraft mc = Minecraft.getInstance();
       boolean isLocalPlayer = mc.player != null && mc.player.getUUID().equals(entity.getUUID());
-      if (isLocalPlayer) {
-         return !isDisableSelfModel();
-      } else {
-         return !isDisableOtherModel();
+
+      // 官方 YSM：模型激活且未按自/他开关禁用。
+      if (isOfficialYsmModelActive(entity)) {
+         boolean disabled = isLocalPlayer
+                 ? getBooleanValue(disableSelfModelValue)
+                 : getBooleanValue(disableOtherModelValue);
+         if (!disabled) {
+            return true;
+         }
       }
+
+      // Sparkle's Morpher：自带自/他开关语义，激活时让出渲染权。
+      return SparkleMorpherCompat.isSparkleActive(entity);
    }
 
-   /**
-    * 判断实体是否配置了 YSM 模型（无论当前是否显示）
-    */
    public static boolean isYsmModelActive(LivingEntity entity) {
+      return isOfficialYsmModelActive(entity) || SparkleMorpherCompat.isSparkleModelActive(entity);
+   }
+
+   private static boolean isOfficialYsmModelActive(LivingEntity entity) {
       if (!ysmChecked) {
          ysmPresent = ModList.get().isLoaded("yes_steve_model");
          if (ysmPresent) {
@@ -89,17 +95,17 @@ public class YsmCompat {
 
    /** 获取 YSM 是否开启了“阻止自身模型渲染” */
    public static boolean isDisableSelfModel() {
-      return getBooleanValue(disableSelfModelValue);
+      return getBooleanValue(disableSelfModelValue) || SparkleMorpherCompat.isDisableSelfModel();
    }
 
    /** 获取 YSM 是否开启了“阻止其他玩家模型渲染” */
    public static boolean isDisableOtherModel() {
-      return getBooleanValue(disableOtherModelValue);
+      return getBooleanValue(disableOtherModelValue) || SparkleMorpherCompat.isDisableOtherModel();
    }
 
    /** 获取 YSM 是否开启了“阻止自身手臂渲染” */
    public static boolean isDisableSelfHands() {
-      return getBooleanValue(disableSelfHandsValue);
+      return getBooleanValue(disableSelfHandsValue) || SparkleMorpherCompat.isDisableSelfHands();
    }
 
    private static boolean getBooleanValue(Object valueObj) {


### PR DESCRIPTION
## 背景

Sparkle's Morpher（mod id `sparkle_morpher`，OpenYSM 衍生的玩家模型加载器）与 MC-MMD 在 1.21.1 上都向 `PlayerRenderer.render` 注入 `@At("HEAD")` 且 `cancellable = true`，各自在模型激活时 `ci.cancel()`。两者同实例共存时会争夺同一帧的渲染权，谁先 cancel 谁赢，行为取决于加载顺序，不可预期。

MC-MMD 已有对官方 YSM 的让步机制（`YsmCompat.isYsmActive()` → `PlayerVanillaRenderPolicy` 返回 `CANCEL`/`FALLTHROUGH`），但该检测写死了官方 YSM 的 mod id 与包名（`yes_steve_model` / `com.elfmcys.yesstevemodel`），因此**识别不出 Sparkle's Morpher**，让步分支永不触发。

## 改动

- 新增 `common/.../compat/SparkleMorpherCompat`：纯反射访问 Sparkle's Morpher 的公开 API（放在与 `IrisCompat` 同级，沿用同一反射写法）：
  - `com.micaftic.morpher.YesSteveModel.isAvailable()`
  - `PlayerCapability.get(Entity) → Optional` → `cap.isModelActive()`
  - `GeneralConfig.DISABLE_SELF_MODEL / DISABLE_OTHER_MODEL / DISABLE_SELF_HANDS`（`ForgeConfigSpec.BooleanValue`，`.get()`）
- Fabric / NeoForge 两端 `YsmCompat` 改为同时查询 Sparkle's Morpher：
  - `isYsmModelActive` 对两系统做 OR（相机 / 手部 / 关卡 mixin 也能识别）；
  - `isYsmActive` 在「官方 YSM(激活且未禁用) 或 Sparkle's Morpher(激活且未禁用)」时让出渲染权，每套系统各自用自身的自/他开关；
  - 公开 `isDisable*` getter 对两系统开关做 OR（只装一个时结果正确，保守合并）。

未引入硬依赖；Sparkle's Morpher 缺失时所有反射查询 fail-closed 返回 `false`，与现有官方 YSM 路径行为一致。

## 未验证项

本地无法运行该项目 Gradle 8.8 构建（宿主仅 JDK 25，且无 JDK 21），故未在本地编译验证。改动严格对照仓库现有 `IrisCompat` 的反射约定与官方 YSM 反射模式，建议由 CI / JDK 21 环境验证。

## 兼容性

- 官方 YSM 路径行为不变（`isOfficialYsmModelActive` 即原 `isYsmModelActive` 逻辑）。
- 不安装 Sparkle's Morpher 时，`SparkleMorpherCompat` 全部返回 `false`，等同于无操作。
- 仅安装官方 YSM、仅安装 Sparkle's Morpher、两者都装 三种情形下，渲染让步语义均自洽。
